### PR TITLE
Add timing data support, config-driven simulation, and CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +387,52 @@ dependencies = [
  "chrono",
  "phf",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "comfy-table"
@@ -1143,6 +1239,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,6 +1470,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
@@ -2411,7 +2519,10 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 name = "rusty-trains"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "polars",
+ "serde",
+ "serde_yaml_ng",
 ]
 
 [[package]]
@@ -2537,6 +2648,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.9.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd24347956e682cf958c95e82deb9914cad4010d3efc035d579f81f4c426038c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2698,6 +2822,12 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum_macros"
@@ -2973,6 +3103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3001,6 +3137,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,7 @@ edition = "2024"
 license = "MIT"
 
 [dependencies]
-polars = { version = "0.53", features = ["parquet"] }
+polars       = { version = "0.53", features = ["parquet"] }
+serde        = { version = "1",    features = ["derive"] }
+serde_yaml_ng = "0.9"
+clap         = { version = "4",    features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,124 @@
+# rusty-trains
+
+A train network simulator written in Rust. Supports two simulation modes:
+
+- **Physics** — integrates Newton's equations of motion using a configurable train description, environment, and driver input.
+- **Timing** — replays real berth timing data from a Parquet file, producing a position trace without kinematic assumptions.
+
+## Prerequisites
+
+| Tool | Purpose |
+|------|---------|
+| [Rust + Cargo](https://rustup.rs) | Build the simulator |
+| [uv](https://docs.astral.sh/uv/) | Run the Python data-generation scripts |
+
+## Build
+
+```sh
+cargo build --release
+```
+
+The binary is written to `target/release/rusty-trains`.
+
+## Usage
+
+```
+rusty-trains <config.yaml> <output.parquet>
+```
+
+| Argument | Description |
+|----------|-------------|
+| `<config.yaml>` | Simulation configuration (see below) |
+| `<output.parquet>` | Destination for the result table |
+
+Run `rusty-trains --help` for a brief usage summary.
+
+## Simulation modes
+
+### Physics simulation
+
+Integrate train motion using the Davis equation, aerodynamic drag, and gravity.
+
+Config (`config_physics.yaml`):
+
+```yaml
+simulation:
+  type: physics
+
+  train:
+    power: 2460000.0                        # W
+    traction_force_at_standstill: 409000.0  # N
+    max_speed: 120.0                        # km/h
+    mass: 2000000.0                         # kg
+    drag_coeff: 10.0                        # kg/m
+    braking_force: 800000.0                 # N
+
+  environment:
+    gradient: 0.01      # rise/run (positive = uphill)
+    wind_speed: 0.0     # m/s (head-wind positive)
+
+  driver:
+    power_ratio: 0.8    # 0–1 throttle
+    break_ratio: 0.0    # 0–1 braking
+
+  time_step_s: 0.1      # integration step
+  duration_s: 2000.0    # total simulated time
+```
+
+Output columns: `time_s`, `position_m`, `speed_kmh`, `acceleration_mss`.
+
+Run:
+
+```sh
+cargo run --release -- config_physics.yaml output_physics.parquet
+```
+
+### Timing-based replay
+
+Load berth step events for a specific train from a Parquet file and
+produce a position trace ordered by timestamp.
+
+Config (`config_timing.yaml`):
+
+```yaml
+simulation:
+  type: timing
+  parquet_file: berth_timing.parquet
+  train_id: "1A23"
+```
+
+Output columns: `timestamp_ms`, `position_m`.
+
+Speed and acceleration are not available from berth timing data.
+
+Run:
+
+```sh
+cargo run --release -- config_timing.yaml output_timing.parquet
+```
+
+## Generating sample timing data
+
+`make_timing_parquet.py` generates a synthetic berth timing Parquet file
+that matches the expected schema:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `train_id` | UTF8 | Train identifier / headcode |
+| `berth_id` | UTF8 | Berth name |
+| `timestamp_ms` | INT64 | Unix timestamp, milliseconds |
+| `position_m` | DOUBLE | Along-track distance from route origin, metres |
+
+```sh
+# Default: trains 1A23, 2B45, 3C67 × 12 berths each
+uv run make_timing_parquet.py berth_timing.parquet
+
+# Custom trains and berth count
+uv run make_timing_parquet.py berth_timing.parquet --trains 1A23 2B45 --berths 20
+```
+
+## Running the tests
+
+```sh
+cargo test
+```

--- a/config_physics.yaml
+++ b/config_physics.yaml
@@ -1,0 +1,21 @@
+simulation:
+  type: physics
+
+  train:
+    power: 2460000.0                    # W  (max traction power)
+    traction_force_at_standstill: 409000.0  # N
+    max_speed: 120.0                    # km/h
+    mass: 2000000.0                     # kg
+    drag_coeff: 10.0                    # kg/m (aerodynamic)
+    braking_force: 800000.0             # N
+
+  environment:
+    gradient: 0.01                      # rise/run (1 % uphill)
+    wind_speed: 0.0                     # m/s (head-wind positive)
+
+  driver:
+    power_ratio: 0.8                    # 0–1 throttle
+    break_ratio: 0.0                    # 0–1 braking
+
+  time_step_s: 0.1                      # integration step (s)
+  duration_s:  2000.0                   # total simulated time (s)

--- a/config_timing.yaml
+++ b/config_timing.yaml
@@ -1,0 +1,4 @@
+simulation:
+  type: timing
+  parquet_file: berth_timing.parquet   # path to the berth timing Parquet file
+  train_id: "1A23"                     # headcode / train identifier to load

--- a/make_timing_parquet.py
+++ b/make_timing_parquet.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Generate a sample berth timing Parquet file for rusty-trains.
+
+Each row represents a berth step event: the moment a train's description
+moved into a new berth on the signalling panel.
+
+Columns produced
+----------------
+train_id     : str   – Train identifier / headcode, e.g. "1A23"
+berth_id     : str   – Berth name (matches BerthDescription::name in the model)
+timestamp_ms : int64 – Unix epoch timestamp in milliseconds
+position_m   : float – Along-track distance from route origin, in metres
+
+Usage
+-----
+    uv run make_timing_parquet.py berth_timing.parquet
+    uv run make_timing_parquet.py berth_timing.parquet --trains 1A23 2B45 --berths 15
+"""
+
+import argparse
+import random
+from datetime import datetime, timezone
+
+import pandas as pd
+
+
+def make_berth_timing(
+    train_id: str,
+    n_berths: int,
+    start_time_ms: int,
+    start_pos_m: float = 0.0,
+) -> list[dict]:
+    """Return rows for one train moving through *n_berths* berths."""
+    rng = random.Random(hash(train_id))  # reproducible per train ID
+    rows = []
+    t = start_time_ms
+    x = start_pos_m
+    for i in range(n_berths):
+        rows.append(
+            {
+                "train_id": train_id,
+                "berth_id": f"{train_id}_B{i + 1:02d}",
+                "timestamp_ms": t,
+                "position_m": round(x, 1),
+            }
+        )
+        x += rng.uniform(600.0, 1400.0)   # 600–1400 m between berth boundaries
+        t += int(rng.uniform(45.0, 150.0) * 1000)  # 45–150 s travel time
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate a sample berth timing Parquet file."
+    )
+    parser.add_argument("output", help="Output Parquet file path")
+    parser.add_argument(
+        "--trains",
+        nargs="+",
+        default=["1A23", "2B45", "3C67"],
+        metavar="HEADCODE",
+        help="Train identifiers to generate (default: 1A23 2B45 3C67)",
+    )
+    parser.add_argument(
+        "--berths",
+        type=int,
+        default=12,
+        metavar="N",
+        help="Number of berths per train (default: 12)",
+    )
+    args = parser.parse_args()
+
+    # Trains depart 5 minutes apart from a fixed reference time.
+    base_time_ms = int(
+        datetime(2024, 1, 15, 8, 0, 0, tzinfo=timezone.utc).timestamp() * 1000
+    )
+
+    all_rows: list[dict] = []
+    for i, train_id in enumerate(args.trains):
+        start_ms = base_time_ms + i * 5 * 60 * 1000  # 5-minute headway
+        all_rows.extend(make_berth_timing(train_id, args.berths, start_ms))
+
+    df = pd.DataFrame(all_rows).astype(
+        {"train_id": "string", "berth_id": "string", "timestamp_ms": "int64", "position_m": "float64"}
+    )
+    df.to_parquet(args.output, index=False)
+
+    print(f"Written {len(df)} rows ({len(args.trains)} trains × {args.berths} berths) to '{args.output}'")
+    print(df.to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,102 +1,149 @@
 mod physics;
 mod model;
+mod timing;
 
-use model::{DriverInput, TrainState, TrainDescription, Environment, Position};
-use physics::{step_trains, advance_train, AdvanceTarget};
+use model::{SimulatedState, TrainDescription, Environment, DriverInput, Position, TrainState};
+use physics::step_trains;
 use polars::prelude::*;
+use clap::Parser;
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+/// Train network simulator.
+///
+/// Runs either a physics-based simulation or replays real timing data,
+/// writing the result to a Parquet file.
+#[derive(Parser)]
+#[command(name = "rusty-trains", version)]
+struct Cli {
+    /// Path to the simulation config YAML file.
+    config: std::path::PathBuf,
+
+    /// Path to write the output Parquet file.
+    output: std::path::PathBuf,
+}
+
+// ---------------------------------------------------------------------------
+// Configuration structs (deserialized from YAML)
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Deserialize)]
+struct Config {
+    simulation: SimulationConfig,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum SimulationConfig {
+    Physics {
+        train: TrainDescription,
+        environment: Environment,
+        driver: DriverInput,
+        time_step_s: f64,
+        duration_s: f64,
+    },
+    Timing {
+        parquet_file: String,
+        train_id: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
 
 fn main() {
+    let cli = Cli::parse();
+    let config_path = &cli.config;
+    let output_path = &cli.output;
 
-    let mut time_data: Vec<f64> = Vec::new();
-    let mut speed_data: Vec<f64> = Vec::new();
-    let mut position_data: Vec<f64> = Vec::new();
-    let mut acceleration_data: Vec<f64> = Vec::new();
+    let config_str = std::fs::read_to_string(config_path)
+        .unwrap_or_else(|e| { eprintln!("Cannot read config '{}': {e}", config_path.display()); std::process::exit(1) });
+    let config: Config = serde_yaml_ng::from_str(&config_str)
+        .unwrap_or_else(|e| { eprintln!("Invalid config: {e}"); std::process::exit(1) });
 
-    let mut state = TrainState {
-        position: Position{x: 0., y: 0., z: 0.},
-        speed: 0.0,
-        acceleration: 0.0,
+    let mut df = match config.simulation {
+        SimulationConfig::Physics { train, environment, driver, time_step_s, duration_s } => {
+            println!("Running physics simulation (dt={time_step_s}s, duration={duration_s}s)");
+            run_physics(&train, &environment, &driver, time_step_s, duration_s)
+        }
+        SimulationConfig::Timing { parquet_file, train_id } => {
+            println!("Loading timing data for train '{train_id}' from '{parquet_file}'");
+            run_timing(&parquet_file, &train_id)
+        }
     };
 
-    let params = TrainDescription {
-        power: 2_460_000.0,
-        traction_force_at_standstill: 409_000.,
-        max_speed: 120.,
-        mass: 2_000_000.0,
-        drag_coeff: 10.0,
-        braking_force: 800_000.0,
-    };
-
-    let driver_input = DriverInput {
-        power_ratio: 0.8,
-        break_ratio: 0.0,
-    };
-
-    let env = Environment {
-        wind_speed: 0.,
-        gradient: 0.01,
-    };
-
-    let dt = 0.1; // 0.1 second time step
-
-    for step in 0..20_000 {
-        state = step_trains(&state, &params, &driver_input, &env, dt);
-        time_data.push(step as f64 * dt);
-        speed_data.push(state.speed * 3.6);
-        position_data.push(state.position.x);
-        acceleration_data.push(state.acceleration);
-        println!(
-            "t={:>4}s  pos={:>8.1}m  speed={:.2} m/s ({:.1} km/h)",
-            step as f64*dt,
-            state.position.x,
-            state.speed,
-            state.speed * 3.6
-        );
-    }
-
-    let mut df = DataFrame::new(
-        time_data.len(),
-        vec![
-            Series::new("time_s".into(), &time_data).into(),
-            Series::new("speed_kmh".into(), &speed_data).into(),
-            Series::new("position_m".into(), &position_data).into(),
-            Series::new("acceleration".into(), &acceleration_data).into(),
-        ]
-    ).unwrap();
-
-    let file = std::fs::File::create("simulation.parquet").unwrap();
+    let file = std::fs::File::create(output_path)
+        .unwrap_or_else(|e| { eprintln!("Cannot create '{}': {e}", output_path.display()); std::process::exit(1) });
     ParquetWriter::new(file).finish(&mut df).unwrap();
+    println!("Written {} rows to '{}'", df.height(), output_path.display());
+}
 
-    // --- advance_train simulation (coarse 100 s steps) ---
-    let dt_adv = 100.0_f64;
-    let n_adv = (2000.0 / dt_adv) as usize;
+// ---------------------------------------------------------------------------
+// Simulation runners
+// ---------------------------------------------------------------------------
 
-    let mut time_adv:     Vec<f64> = Vec::new();
-    let mut speed_adv:    Vec<f64> = Vec::new();
-    let mut position_adv: Vec<f64> = Vec::new();
+fn run_physics(
+    train: &TrainDescription,
+    env: &Environment,
+    driver: &DriverInput,
+    dt: f64,
+    duration: f64,
+) -> DataFrame {
+    let steps = (duration / dt).round() as usize;
+    let mut time_s_data       = Vec::with_capacity(steps);
+    let mut position_m_data   = Vec::with_capacity(steps);
+    let mut speed_kmh_data    = Vec::with_capacity(steps);
+    let mut accel_mss_data    = Vec::with_capacity(steps);
 
-    let mut state_adv = TrainState {
-        position: Position { x: 0., y: 0., z: 0. },
+    let mut state = SimulatedState {
+        position: Position { x: 0.0, y: 0.0, z: 0.0 },
         speed: 0.0,
         acceleration: 0.0,
     };
 
-    for step in 0..n_adv {
-        state_adv = advance_train(&state_adv, &params, &driver_input, &env, AdvanceTarget::Time(dt_adv));
-        time_adv.push((step + 1) as f64 * dt_adv);
-        speed_adv.push(state_adv.speed * 3.6);
-        position_adv.push(state_adv.position.x);
+    for step in 0..steps {
+        state = step_trains(&state, train, driver, env, dt);
+        time_s_data.push((step + 1) as f64 * dt);
+        position_m_data.push(state.position.x);
+        speed_kmh_data.push(state.speed * 3.6);
+        accel_mss_data.push(state.acceleration);
     }
 
-    let mut df_adv = DataFrame::new(
-        time_adv.len(),
+    DataFrame::new(
+        time_s_data.len(),
         vec![
-            Series::new("time_s".into(),    &time_adv).into(),
-            Series::new("speed_kmh".into(), &speed_adv).into(),
-            Series::new("position_m".into(),&position_adv).into(),
-        ]
-    ).unwrap();
+            Series::new("time_s".into(),          &time_s_data).into(),
+            Series::new("position_m".into(),       &position_m_data).into(),
+            Series::new("speed_kmh".into(),        &speed_kmh_data).into(),
+            Series::new("acceleration_mss".into(), &accel_mss_data).into(),
+        ],
+    ).unwrap()
+}
 
-    let file_adv = std::fs::File::create("simulation_advance.parquet").unwrap();
-    ParquetWriter::new(file_adv).finish(&mut df_adv).unwrap();
+fn run_timing(parquet_file: &str, train_id: &str) -> DataFrame {
+    let states = timing::load_timing_from_parquet(
+        std::path::Path::new(parquet_file),
+        train_id,
+    ).unwrap_or_else(|e| { eprintln!("Error loading timing data: {e}"); std::process::exit(1) });
+
+    let mut timestamp_ms_data = Vec::with_capacity(states.len());
+    let mut position_m_data   = Vec::with_capacity(states.len());
+
+    for state in &states {
+        if let TrainState::Observed(o) = state {
+            timestamp_ms_data.push(o.timestamp_ms);
+            position_m_data.push(o.position.x);
+        }
+    }
+
+    DataFrame::new(
+        timestamp_ms_data.len(),
+        vec![
+            Series::new("timestamp_ms".into(), &timestamp_ms_data).into(),
+            Series::new("position_m".into(),   &position_m_data).into(),
+        ],
+    ).unwrap()
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -11,20 +11,60 @@ pub struct Trajectory {
     pub points: Vec<Position>,
 }
 
-#[derive(Debug,Clone)]
+#[derive(Debug, Clone, serde::Deserialize)]
 pub struct DriverInput {
     pub break_ratio: f64,
     pub power_ratio: f64,
 }
 
+/// Train state produced by the physics engine. All kinematic fields are always
+/// known, so they are stored as plain `f64`.
 #[derive(Debug, Clone)]
-pub struct TrainState {
-    pub position: Position,  // meters
-    pub speed: f64,     // m/s
-    pub acceleration: f64,
+pub struct SimulatedState {
+    pub position: Position,   // metres
+    pub speed: f64,           // m/s
+    pub acceleration: f64,    // m/s²
 }
 
+/// Train state derived from berth timing data. Speed and acceleration are not
+/// available from timing records, so only position and timestamp are stored.
 #[derive(Debug, Clone)]
+pub struct ObservedState {
+    pub position: Position,   // metres along route
+    pub timestamp_ms: i64,    // Unix epoch, milliseconds
+}
+
+/// A train's state, which is either physics-simulated or timing-observed.
+#[derive(Debug, Clone)]
+pub enum TrainState {
+    Simulated(SimulatedState),
+    Observed(ObservedState),
+}
+
+impl TrainState {
+    pub fn position(&self) -> &Position {
+        match self {
+            TrainState::Simulated(s) => &s.position,
+            TrainState::Observed(o)  => &o.position,
+        }
+    }
+
+    pub fn speed(&self) -> Option<f64> {
+        match self {
+            TrainState::Simulated(s) => Some(s.speed),
+            TrainState::Observed(_)  => None,
+        }
+    }
+
+    pub fn acceleration(&self) -> Option<f64> {
+        match self {
+            TrainState::Simulated(s) => Some(s.acceleration),
+            TrainState::Observed(_)  => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
 pub struct TrainDescription {
     pub power: f64,       // Max Watts
     pub traction_force_at_standstill: f64, // N
@@ -34,7 +74,7 @@ pub struct TrainDescription {
     pub braking_force: f64, // Newtons, maximum braking force
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Deserialize)]
 pub struct Environment {
     pub wind_speed: f64,
     pub gradient: f64,    // rise/run (e.g. 0.01 = 1% grade)

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -1,4 +1,4 @@
-use crate::model::{DriverInput, TrainState, TrainDescription, Environment, Position};
+use crate::model::{DriverInput, SimulatedState, TrainDescription, Environment, Position};
 
 
 const G: f64 = 9.81; // m/s²
@@ -24,7 +24,7 @@ fn net_force_at_speed(v: f64, params: &TrainDescription, driver: &DriverInput, e
     traction_force - gravity_force - drag_force - rolling_resistance - braking_force
 }
 
-fn compute_acceleration(state: &TrainState, params: &TrainDescription, driver: &DriverInput, env: &Environment) -> f64 {
+fn compute_acceleration(state: &SimulatedState, params: &TrainDescription, driver: &DriverInput, env: &Environment) -> f64 {
     net_force_at_speed(state.speed, params, driver, env) / params.mass
 }
 
@@ -52,7 +52,7 @@ fn terminal_speed(v_lo: f64, v_hi: f64, params: &TrainDescription, driver: &Driv
 /// equilibrium speed where net force = 0.  When the projected speed would cross
 /// that point the motion is split into two phases — accelerate/decelerate to
 /// equilibrium, then cruise — exactly as is done for the track speed limit.
-pub fn advance_train(state: &TrainState, params: &TrainDescription, driver: &DriverInput, env: &Environment, target: AdvanceTarget) -> TrainState {
+pub fn advance_train(state: &SimulatedState, params: &TrainDescription, driver: &DriverInput, env: &Environment, target: AdvanceTarget) -> SimulatedState {
     let a    = compute_acceleration(state, params, driver, env);
     let v0   = state.speed;
     let x0   = state.position.x;
@@ -100,7 +100,7 @@ pub fn advance_train(state: &TrainState, params: &TrainDescription, driver: &Dri
             if v_sq <= 0.0 {
                 // Decelerating — train stops before covering dx.
                 let stop_dist = v0 * v0 / (2.0 * a.abs());
-                return TrainState {
+                return SimulatedState {
                     position: Position { x: x0 + stop_dist, y: 0.0, z: 0.0 },
                     speed: 0.0,
                     acceleration: a,
@@ -115,14 +115,14 @@ pub fn advance_train(state: &TrainState, params: &TrainDescription, driver: &Dri
         }
     };
 
-    TrainState {
+    SimulatedState {
         position: Position { x: new_position, y: 0.0, z: 0.0 },
         speed: new_speed,
         acceleration: a,
     }
 }
 
-pub fn step_trains(state: &TrainState, params: &TrainDescription, driver: &DriverInput, env: &Environment, dt: f64) -> TrainState {
+pub fn step_trains(state: &SimulatedState, params: &TrainDescription, driver: &DriverInput, env: &Environment, dt: f64) -> SimulatedState {
     let speed = state.speed;
     let breaking = driver.break_ratio>0.0;
 
@@ -160,7 +160,7 @@ pub fn step_trains(state: &TrainState, params: &TrainDescription, driver: &Drive
 
     let new_position = state.position.x + speed * dt; // use old speed for position update
 
-    TrainState {
+    SimulatedState {
         position: Position{x:new_position,y:0., z:0.},
         speed: new_speed,
         acceleration: acceleration,
@@ -170,7 +170,7 @@ pub fn step_trains(state: &TrainState, params: &TrainDescription, driver: &Drive
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{DriverInput, Environment, Position, TrainDescription, TrainState};
+    use crate::model::{DriverInput, Environment, Position, TrainDescription, SimulatedState};
 
     fn test_params() -> TrainDescription {
         TrainDescription {
@@ -183,12 +183,12 @@ mod tests {
         }
     }
 
-    fn initial_state(speed: f64) -> TrainState {
-        TrainState { position: Position { x: 0.0, y: 0.0, z: 0.0 }, speed, acceleration: 0.0 }
+    fn initial_state(speed: f64) -> SimulatedState {
+        SimulatedState { position: Position { x: 0.0, y: 0.0, z: 0.0 }, speed, acceleration: 0.0 }
     }
 
     /// Reference: run step_trains with fine 0.1 s steps for total_time seconds.
-    fn step_reference(s0: &TrainState, p: &TrainDescription, d: &DriverInput, e: &Environment, total_time: f64) -> TrainState {
+    fn step_reference(s0: &SimulatedState, p: &TrainDescription, d: &DriverInput, e: &Environment, total_time: f64) -> SimulatedState {
         let dt = 0.1;
         let n = (total_time / dt).round() as usize;
         let mut state = s0.clone();
@@ -196,7 +196,7 @@ mod tests {
         state
     }
 
-    fn assert_within(label: &str, result: &TrainState, reference: &TrainState) {
+    fn assert_within(label: &str, result: &SimulatedState, reference: &SimulatedState) {
         let speed_tol = 1.0_f64; // m/s
         let pos_tol   = 5.0_f64; // m
         let dv = (result.speed - reference.speed).abs();

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -1,0 +1,63 @@
+use polars::prelude::*;
+use std::fs::File;
+use std::path::Path;
+use std::sync::Arc;
+use crate::model::{ObservedState, Position, TrainState};
+
+/// Read berth timing data from a Parquet file and return a time-ordered list
+/// of [`TrainState::Observed`] values for the given `train_id`.
+///
+/// # Parquet file format
+///
+/// Each row represents a single berth step event — the moment a train's
+/// description stepped into the named berth on the signalling panel.
+///
+/// | Column         | Parquet type | Description                                           |
+/// |----------------|--------------|-------------------------------------------------------|
+/// | `train_id`     | UTF8         | Train identifier / headcode, e.g. `"1A23"`            |
+/// | `berth_id`     | UTF8         | Berth name, matching `BerthDescription::name`         |
+/// | `timestamp_ms` | INT64        | Unix epoch timestamp in **milliseconds**              |
+/// | `position_m`   | DOUBLE       | Along-track distance from route origin, in **metres** |
+///
+/// Rows do not need to be pre-sorted; the loader sorts by `timestamp_ms`.
+/// Rows with null values in `timestamp_ms` or `position_m` are skipped.
+///
+/// # Limitations
+///
+/// Speed and acceleration cannot be derived from berth timing data alone.
+/// All returned states are [`TrainState::Observed`]; call `.speed()` or
+/// `.acceleration()` on them to get `None`.
+pub fn load_timing_from_parquet(
+    path: &Path,
+    train_id: &str,
+) -> PolarsResult<Vec<TrainState>> {
+    let file = File::open(path)
+        .map_err(|e| PolarsError::IO { error: Arc::new(e), msg: None })?;
+    let df = ParquetReader::new(file).finish()?;
+
+    // Filter rows matching the requested train_id.
+    let train_id_col = df.column("train_id")?.str()?;
+    let mask: BooleanChunked = train_id_col
+        .into_iter()
+        .map(|v| v == Some(train_id))
+        .collect();
+    let df = df.filter(&mask)?;
+
+    // Sort chronologically.
+    let df = df.sort(["timestamp_ms"], SortMultipleOptions::default())?;
+
+    let timestamps = df.column("timestamp_ms")?.i64()?;
+    let positions  = df.column("position_m")?.f64()?;
+
+    let mut result = Vec::with_capacity(df.height());
+    for i in 0..df.height() {
+        let Some(ts)  = timestamps.get(i) else { continue };
+        let Some(pos) = positions.get(i)  else { continue };
+        result.push(TrainState::Observed(ObservedState {
+            position: Position { x: pos, y: 0.0, z: 0.0 },
+            timestamp_ms: ts,
+        }));
+    }
+
+    Ok(result)
+}


### PR DESCRIPTION
## Summary

- **New `TrainState` enum** (`Simulated` / `Observed`) gives physics and berth timing data a shared type while keeping kinematics genuinely optional — `speed()` and `acceleration()` return `Option<f64>` and are `None` for timing-derived states
- **`src/timing.rs`** reads berth timing Parquet files and produces `TrainState::Observed` values (position + timestamp; no speed/accel)
- **Config-driven `main.rs`** — a YAML file selects the simulation mode (`physics` or `timing`) and all parameters; the output path is a CLI argument
- **`clap`** for ergonomic CLI parsing with auto-generated `--help` / `--version`
- **`serde` + `serde_yaml_ng`** (the actively maintained serde-yaml fork) for config deserialisation
- **`config_physics.yaml` / `config_timing.yaml`** — ready-to-use example configs
- **`make_timing_parquet.py`** — Python script (uses existing `pandas` + `pyarrow` deps) to generate synthetic berth timing data matching the expected schema
- **`README.md`** — build instructions, usage, config format, and Parquet schema docs

## Parquet schema for berth timing data

| Column | Type | Description |
|---|---|---|
| `train_id` | UTF8 | Train identifier / headcode |
| `berth_id` | UTF8 | Berth name |
| `timestamp_ms` | INT64 | Unix timestamp, milliseconds |
| `position_m` | DOUBLE | Along-track distance from route origin, metres |

## Test plan

- [ ] `cargo test` passes
- [ ] `uv run make_timing_parquet.py berth_timing.parquet` generates a valid file
- [ ] `cargo run -- config_physics.yaml out.parquet` runs physics simulation and writes output
- [ ] `cargo run -- config_timing.yaml out.parquet` loads timing data and writes output
- [ ] `rusty-trains --help` shows correct usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)