### PR TITLE
Progress bar, Rayon parallelism, and row-based flushing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2566,6 +2566,7 @@ dependencies = [
  "clap",
  "indicatif",
  "polars",
+ "rayon",
  "serde",
  "serde_yaml_ng",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +651,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -1223,6 +1242,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,6 +1452,12 @@ dependencies = [
  "autocfg",
  "libm",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -2116,6 +2154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,6 +2564,7 @@ name = "rusty-trains"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "indicatif",
  "polars",
  "serde",
  "serde_yaml_ng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ serde        = { version = "1",    features = ["derive"] }
 serde_yaml_ng = "0.9"
 clap         = { version = "4",    features = ["derive"] }
 indicatif    = "0.17"
+rayon        = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ polars       = { version = "0.53", features = ["parquet"] }
 serde        = { version = "1",    features = ["derive"] }
 serde_yaml_ng = "0.9"
 clap         = { version = "4",    features = ["derive"] }
+indicatif    = "0.17"

--- a/scripts/run_100trains.py
+++ b/scripts/run_100trains.py
@@ -67,6 +67,7 @@ def main(
     dt: Annotated[float, typer.Option(help="Time step in seconds")] = 1.0,
     duration: Annotated[float, typer.Option(help="Simulation duration in hours")] = 1.0,
     seed: Annotated[int, typer.Option(help="Random seed for reproducibility")] = SEED,
+    flush_rows: Annotated[int, typer.Option(help="Max rows buffered before a Parquet flush")] = 1_000_000,
 ) -> None:
     """Generate a physics config for N trains and print the command to run it."""
     rng = random.Random(seed)
@@ -75,6 +76,7 @@ def main(
         "simulation": {
             "time_step_s": dt,
             "duration_s": duration * 3_600,
+            "flush_rows": flush_rows,
             "trains": [make_train(i, rng) for i in range(1, trains + 1)],
         }
     }
@@ -84,7 +86,8 @@ def main(
     expected_rows = int(duration * 3_600 / dt) * trains
     typer.echo(
         f"Wrote {config}  "
-        f"({trains} trains, {duration}h @ {dt}s steps, ~{expected_rows:,} output rows)"
+        f"({trains} trains, {duration}h @ {dt}s steps, ~{expected_rows:,} output rows, "
+        f"flush every {flush_rows:,} rows)"
     )
 
     typer.echo("\nTo run the simulation:")

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use physics::step_trains;
 use timing::TimingTrace;
 use polars::prelude::*;
 use clap::Parser;
+use indicatif::{ProgressBar, ProgressStyle};
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -163,6 +164,15 @@ fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::
 
     let mut total_rows: usize = 0;
 
+    let pb = ProgressBar::new(steps as u64);
+    pb.set_style(
+        ProgressStyle::with_template(
+            "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} steps ({percent}%) ETA: {eta}"
+        )
+        .unwrap()
+        .progress_chars("█▉▊▋▌▍▎▏ "),
+    );
+
     for step in 0..steps {
         let t = (step + 1) as f64 * dt;
 
@@ -202,7 +212,7 @@ fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::
             writer.write_batch(&batch)
                 .unwrap_or_else(|e| { eprintln!("Write error at step {step}: {e}"); std::process::exit(1) });
             total_rows += n;
-            println!("  flushed {n} rows (total: {total_rows})");
+            pb.println(format!("  flushed {n} rows (total: {total_rows})", ));
 
             train_id_data.clear();
             time_s_data.clear();
@@ -210,8 +220,11 @@ fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::
             speed_kmh_data.clear();
             accel_mss_data.clear();
         }
+
+        pb.inc(1);
     }
 
+    pb.finish_and_clear();
     writer.finish()
         .unwrap_or_else(|e| { eprintln!("Failed to finalise Parquet file: {e}"); std::process::exit(1) });
     println!("Written {total_rows} rows to '{}'", output.display());

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use timing::TimingTrace;
 use polars::prelude::*;
 use clap::Parser;
 use indicatif::{ProgressBar, ProgressStyle};
+use rayon::prelude::*;
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -61,18 +62,18 @@ impl TrainConfig {
     }
 }
 
-fn default_flush_steps() -> usize { 10_000 }
+fn default_flush_rows() -> usize { 1_000_000 }
 
 #[derive(serde::Deserialize)]
 struct SimulationConfig {
     time_step_s: f64,
     duration_s: f64,
     trains: Vec<TrainConfig>,
-    /// Number of time steps between Parquet row-group flushes.
-    /// Smaller values reduce peak memory use at the cost of more I/O.
-    /// Defaults to 10 000.
-    #[serde(default = "default_flush_steps")]
-    flush_steps: usize,
+    /// Maximum number of rows to buffer before flushing a Parquet row group.
+    /// Row-based (not step-based) so the buffer size stays bounded regardless
+    /// of the number of trains. Defaults to 1 000 000.
+    #[serde(default = "default_flush_rows")]
+    flush_rows: usize,
 }
 
 // ---------------------------------------------------------------------------
@@ -91,11 +92,11 @@ fn main() {
 
     let sim = config.simulation;
     println!(
-        "Running simulation: {} train(s), dt={}s, duration={}s, flush every {} steps",
-        sim.trains.len(), sim.time_step_s, sim.duration_s, sim.flush_steps
+        "Running simulation: {} train(s), dt={}s, duration={}s, flush every {} rows",
+        sim.trains.len(), sim.time_step_s, sim.duration_s, sim.flush_rows
     );
 
-    run_simulation(&sim.trains, sim.time_step_s, sim.duration_s, output_path, sim.flush_steps);
+    run_simulation(&sim.trains, sim.time_step_s, sim.duration_s, output_path, sim.flush_rows);
 }
 
 // ---------------------------------------------------------------------------
@@ -113,8 +114,10 @@ enum SimState {
 /// Time is the outer loop: every train is advanced for each time step before
 /// moving to the next step. Physics and timing trains may be freely mixed.
 ///
-/// In-memory buffers hold at most `flush_steps * n_trains` rows at a time;
-/// they are written as a row group and cleared on every flush boundary.
+/// Per-step physics is parallelised with Rayon across all trains.
+///
+/// In-memory buffers hold at most `flush_rows` rows at a time; they are
+/// written as a row group and cleared on every flush boundary.
 ///
 /// Output columns:
 /// - `train_id`         — string identifier
@@ -123,17 +126,19 @@ enum SimState {
 ///                        is outside its data range)
 /// - `speed_kmh`        — speed in km/h (null for timing trains)
 /// - `acceleration_mss` — acceleration in m/s² (null for timing trains)
-fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::path::Path, flush_steps: usize) {
+fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::path::Path, flush_rows: usize) {
     let steps = (duration / dt).round() as usize;
-    let buf_cap = flush_steps * trains.len();
+    let buf_cap = flush_rows.min(steps * trains.len());
 
-    let mut train_id_data   = Vec::<String>::with_capacity(buf_cap);
+    // Pre-cache IDs as &str slices — avoids per-step String allocations in the hot loop.
+    let train_id_cache: Vec<&str> = trains.iter().map(|c| c.id()).collect();
+
     let mut time_s_data     = Vec::<f64>::with_capacity(buf_cap);
     let mut position_m_data = Vec::<Option<f64>>::with_capacity(buf_cap);
     let mut speed_kmh_data  = Vec::<Option<f64>>::with_capacity(buf_cap);
     let mut accel_mss_data  = Vec::<Option<f64>>::with_capacity(buf_cap);
 
-    // Fixed output schema — must match the Series built in flush_batch().
+    // Fixed output schema — must match the Series built at flush time.
     let schema = Schema::from_iter([
         Field::new("train_id".into(),         DataType::String),
         Field::new("time_s".into(),           DataType::Float64),
@@ -145,6 +150,8 @@ fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::
     let file = std::fs::File::create(output)
         .unwrap_or_else(|e| { eprintln!("Cannot create '{}': {e}", output.display()); std::process::exit(1) });
     let mut writer = ParquetWriter::new(file)
+        .with_compression(ParquetCompression::Lz4Raw)
+        .set_parallel(true)
         .batched(&schema)
         .unwrap_or_else(|e| { eprintln!("Cannot initialise Parquet writer: {e}"); std::process::exit(1) });
 
@@ -176,31 +183,40 @@ fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::
     for step in 0..steps {
         let t = (step + 1) as f64 * dt;
 
-        for (cfg, state) in trains.iter().zip(states.iter_mut()) {
-            train_id_data.push(cfg.id().to_string());
-            time_s_data.push(t);
+        // Parallel physics step: each train is independent, so Rayon gives
+        // ~N_cores speedup on the dominant CPU work.
+        let step_results: Vec<(Option<f64>, Option<f64>, Option<f64>)> =
+            trains.par_iter().zip(states.par_iter_mut()).map(|(cfg, state)| {
+                match (cfg, state) {
+                    (TrainConfig::Physics { train, environment, driver, .. }, SimState::Physics(s)) => {
+                        *s = step_trains(s, train, driver, environment, dt);
+                        (Some(s.position.x), Some(s.speed * 3.6), Some(s.acceleration))
+                    }
+                    (TrainConfig::Timing { .. }, SimState::Timing(trace)) => {
+                        (trace.position_at(t), None, None)
+                    }
+                    _ => unreachable!(),
+                }
+            }).collect();
 
-            match (cfg, state) {
-                (TrainConfig::Physics { train, environment, driver, .. }, SimState::Physics(s)) => {
-                    *s = step_trains(s, train, driver, environment, dt);
-                    position_m_data.push(Some(s.position.x));
-                    speed_kmh_data.push(Some(s.speed * 3.6));
-                    accel_mss_data.push(Some(s.acceleration));
-                }
-                (TrainConfig::Timing { .. }, SimState::Timing(trace)) => {
-                    position_m_data.push(trace.position_at(t));
-                    speed_kmh_data.push(None);
-                    accel_mss_data.push(None);
-                }
-                _ => unreachable!(),
-            }
+        for (pos, spd, acc) in step_results {
+            time_s_data.push(t);
+            position_m_data.push(pos);
+            speed_kmh_data.push(spd);
+            accel_mss_data.push(acc);
         }
 
-        if (step + 1) % flush_steps == 0 || step + 1 == steps {
+        if time_s_data.len() >= flush_rows || step + 1 == steps {
+            // Build the train_id column by cycling the cached &str over the accumulated rows.
+            let train_id_col: Vec<&str> = train_id_cache.iter().copied()
+                .cycle()
+                .take(time_s_data.len())
+                .collect();
+            let n = time_s_data.len();
             let batch = DataFrame::new(
-                train_id_data.len(),
+                n,
                 vec![
-                    Series::new("train_id".into(),         &train_id_data).into(),
+                    Series::new("train_id".into(),         &train_id_col).into(),
                     Series::new("time_s".into(),            &time_s_data).into(),
                     Series::new("position_m".into(),        &position_m_data).into(),
                     Series::new("speed_kmh".into(),         &speed_kmh_data).into(),
@@ -208,13 +224,11 @@ fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::
                 ],
             ).unwrap();
 
-            let n = batch.height();
             writer.write_batch(&batch)
                 .unwrap_or_else(|e| { eprintln!("Write error at step {step}: {e}"); std::process::exit(1) });
             total_rows += n;
-            pb.println(format!("  flushed {n} rows (total: {total_rows})", ));
+            pb.println(format!("  flushed {n} rows (total: {total_rows})"));
 
-            train_id_data.clear();
             time_s_data.clear();
             position_m_data.clear();
             speed_kmh_data.clear();


### PR DESCRIPTION
## Summary

- **Progress bar**: adds `indicatif` progress bar showing elapsed time, step count, percentage, and ETA; flush messages print above the bar without disrupting it
- **Rayon parallel physics**: each train's `step_trains` call is independent, so `par_iter` across all trains gives ~N_cores speedup — key for the 10 000-train benchmark
- **Row-based flushing** (`flush_rows`, default 1 000 000): replaces the old step-based `flush_steps`; with 10 000 trains the old default buffered 100 M rows per flush (several GB), the new default caps it at 1 M rows regardless of train count
- **Faster Parquet writes**: switched from Zstd (default) to Lz4Raw compression and enabled parallel column serialisation
- **Pre-cached train IDs**: avoids per-step `String` allocation in the hot loop by cycling `&str` slices at flush time
- **`run_100trains.py`**: exposes `--flush-rows` and writes it into the generated config

## Test plan

- [ ] `cargo build --release` succeeds
- [ ] Run with existing configs (`config/config_physics.yaml`, `config/config_mixed.yaml`) — output unchanged
- [ ] Run benchmark: `uv run scripts/run_100trains.py --trains 10000 --duration 24 && ./target/release/rusty-trains config/config_100trains.yaml out.parquet`
- [ ] Verify output row count: 10 000 trains × 86 400 steps = 864 000 000 rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)