### PR TITLE
Implement discrete event scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,7 +1488,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand",
+ "rand 0.9.2",
  "reqwest",
  "ring",
  "serde",
@@ -1700,7 +1700,7 @@ dependencies = [
  "polars-buffer",
  "polars-error",
  "polars-utils",
- "rand",
+ "rand 0.9.2",
  "serde",
  "strength_reduce",
  "strum_macros",
@@ -1734,7 +1734,7 @@ dependencies = [
  "polars-row",
  "polars-schema",
  "polars-utils",
- "rand",
+ "rand 0.9.2",
  "rand_distr",
  "rayon",
  "regex",
@@ -1794,7 +1794,7 @@ dependencies = [
  "polars-row",
  "polars-time",
  "polars-utils",
- "rand",
+ "rand 0.9.2",
  "rayon",
  "recursive",
  "regex",
@@ -2086,7 +2086,7 @@ dependencies = [
  "polars-plan",
  "polars-time",
  "polars-utils",
- "rand",
+ "rand 0.9.2",
  "rayon",
  "recursive",
  "slotmap",
@@ -2139,7 +2139,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "polars-error",
- "rand",
+ "rand 0.9.2",
  "raw-cpuid",
  "rayon",
  "regex",
@@ -2245,7 +2245,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2288,12 +2288,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2303,7 +2324,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2322,7 +2352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -2566,6 +2596,7 @@ dependencies = [
  "clap",
  "indicatif",
  "polars",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "serde_yaml_ng",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ serde_yaml_ng = "0.9"
 clap         = { version = "4",    features = ["derive"] }
 indicatif    = "0.17"
 rayon        = "1"
+rand         = "0.8"

--- a/config/config_physics.yaml
+++ b/config/config_physics.yaml
@@ -1,5 +1,5 @@
 simulation:
-  time_step_s: 0.1                      # integration step (s)
+  time_step_s: 30.0                     # integration step (s)
   duration_s:  2000.0                   # total simulated time (s)
 
   trains:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
 mod physics;
 mod model;
 mod timing;
+mod scheduler;
 
 use model::{SimulatedState, TrainDescription, Environment, DriverInput, Position};
-use physics::step_trains;
+use physics::{advance_train, AdvanceTarget};
 use timing::TimingTrace;
 use polars::prelude::*;
 use clap::Parser;
@@ -133,14 +134,17 @@ fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::
     // Pre-cache IDs as &str slices — avoids per-step String allocations in the hot loop.
     let train_id_cache: Vec<&str> = trains.iter().map(|c| c.id()).collect();
 
-    let mut time_s_data     = Vec::<f64>::with_capacity(buf_cap);
-    let mut position_m_data = Vec::<Option<f64>>::with_capacity(buf_cap);
-    let mut speed_kmh_data  = Vec::<Option<f64>>::with_capacity(buf_cap);
-    let mut accel_mss_data  = Vec::<Option<f64>>::with_capacity(buf_cap);
+    let mut train_id_data    = Vec::<&str>::with_capacity(buf_cap);
+    let mut event_kind_data  = Vec::<&'static str>::with_capacity(buf_cap);
+    let mut time_s_data      = Vec::<f64>::with_capacity(buf_cap);
+    let mut position_m_data  = Vec::<Option<f64>>::with_capacity(buf_cap);
+    let mut speed_kmh_data   = Vec::<Option<f64>>::with_capacity(buf_cap);
+    let mut accel_mss_data   = Vec::<Option<f64>>::with_capacity(buf_cap);
 
     // Fixed output schema — must match the Series built at flush time.
     let schema = Schema::from_iter([
         Field::new("train_id".into(),         DataType::String),
+        Field::new("event_kind".into(),       DataType::String),
         Field::new("time_s".into(),           DataType::Float64),
         Field::new("position_m".into(),       DataType::Float64),
         Field::new("speed_kmh".into(),        DataType::Float64),
@@ -169,6 +173,58 @@ fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::
         }
     }).collect();
 
+    // -----------------------------------------------------------------------
+    // Build the event queue
+    // -----------------------------------------------------------------------
+
+    let mut queue = scheduler::EventQueue::new();
+
+    // Seed only the first physics tick — subsequent ticks are self-scheduled
+    // from inside the event loop, keeping the queue small at all times.
+    queue.push(dt, None, scheduler::EventKind::PhysicsTick);
+
+    // Seed random placeholder events. Each carries an EntityRef so the
+    // dispatch code can route it to the right object later.
+    {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        let n_trains = trains.len().max(1);
+        let n_random = steps / 10;
+        for _ in 0..n_random {
+            let t = rng.gen_range(0.0f64..duration);
+            let (target, kind) = match rng.gen_range(0u8..4) {
+                0 => (
+                    Some(scheduler::EntityRef::Train(rng.gen_range(0..n_trains))),
+                    scheduler::EventKind::Random(scheduler::RandomEventKind::Departure),
+                ),
+                1 => (
+                    Some(scheduler::EntityRef::Train(rng.gen_range(0..n_trains))),
+                    scheduler::EventKind::Random(scheduler::RandomEventKind::Arrival),
+                ),
+                2 => (
+                    Some(scheduler::EntityRef::Signal(rng.gen_range(0..100usize))),
+                    scheduler::EventKind::Random(scheduler::RandomEventKind::SignalChange),
+                ),
+                _ => (
+                    Some(scheduler::EntityRef::Train(rng.gen_range(0..n_trains))),
+                    scheduler::EventKind::Random(scheduler::RandomEventKind::SpeedChange {
+                        new_speed_kmh: rng.gen_range(0.0f64..120.0),
+                    }),
+                ),
+            };
+            queue.push(t, target, kind);
+        }
+        println!("Event queue seeded: 1 initial physics tick (self-scheduling) + {n_random} random placeholder events");
+    }
+
+    // -----------------------------------------------------------------------
+    // Event-driven simulation loop
+    // -----------------------------------------------------------------------
+
+    // Last simulation time at which each train's state was computed.
+    // Random events advance a single train from here to the event time.
+    let mut last_times: Vec<f64> = vec![0.0; trains.len()];
+
     let mut total_rows: usize = 0;
 
     let pb = ProgressBar::new(steps as u64);
@@ -180,62 +236,144 @@ fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::
         .progress_chars("█▉▊▋▌▍▎▏ "),
     );
 
-    for step in 0..steps {
-        let t = (step + 1) as f64 * dt;
+    while let Some(event) = queue.pop() {
+        // Hard time bound: discard any event (including stray ticks) past the
+        // simulation end. This is the primary stop condition for the loop.
+        if event.time > duration { break; }
 
-        // Parallel physics step: each train is independent, so Rayon gives
-        // ~N_cores speedup on the dominant CPU work.
-        let step_results: Vec<(Option<f64>, Option<f64>, Option<f64>)> =
-            trains.par_iter().zip(states.par_iter_mut()).map(|(cfg, state)| {
-                match (cfg, state) {
-                    (TrainConfig::Physics { train, environment, driver, .. }, SimState::Physics(s)) => {
-                        *s = step_trains(s, train, driver, environment, dt);
-                        (Some(s.position.x), Some(s.speed * 3.6), Some(s.acceleration))
-                    }
-                    (TrainConfig::Timing { .. }, SimState::Timing(trace)) => {
-                        (trace.position_at(t), None, None)
-                    }
-                    _ => unreachable!(),
+        match event.kind {
+            scheduler::EventKind::PhysicsTick => {
+                let t = event.time;
+
+                // Schedule the next tick only if it is still within the simulation
+                // window AND there is meaningful work left: either a train is still
+                // moving, or pending events could change the state (e.g. a future
+                // SpeedChange waking a stopped train).
+                let any_moving = states.iter().any(|s| match s {
+                    SimState::Physics(p) => p.speed > 0.0,
+                    SimState::Timing(_)  => true, // timing traces may still have data
+                });
+                if t + dt <= duration && (any_moving || !queue.is_empty()) {
+                    queue.push(t + dt, None, scheduler::EventKind::PhysicsTick);
                 }
-            }).collect();
 
-        for (pos, spd, acc) in step_results {
-            time_s_data.push(t);
-            position_m_data.push(pos);
-            speed_kmh_data.push(spd);
-            accel_mss_data.push(acc);
+                // Each train advances from its last-known time to t (may differ if
+                // random events have advanced individual trains in between).
+                let step_results: Vec<(Option<f64>, Option<f64>, Option<f64>)> =
+                    trains.par_iter()
+                        .zip(states.par_iter_mut())
+                        .zip(last_times.par_iter())
+                        .map(|((cfg, state), &lt)| {
+                            let dt_i = t - lt;
+                            match (cfg, state) {
+                                (TrainConfig::Physics { train, environment, driver, .. }, SimState::Physics(s)) => {
+                                    if dt_i > 0.0 {
+                                        *s = advance_train(s, train, driver, environment, AdvanceTarget::Time(dt_i));
+                                    }
+                                    (Some(s.position.x), Some(s.speed * 3.6), Some(s.acceleration))
+                                }
+                                (TrainConfig::Timing { .. }, SimState::Timing(trace)) => {
+                                    (trace.position_at(t), None, None)
+                                }
+                                _ => unreachable!(),
+                            }
+                        })
+                        .collect();
+
+                last_times.iter_mut().for_each(|lt| *lt = t);
+
+                for (i, (pos, spd, acc)) in step_results.into_iter().enumerate() {
+                    train_id_data.push(train_id_cache[i]);
+                    event_kind_data.push("physics_tick");
+                    time_s_data.push(t);
+                    position_m_data.push(pos);
+                    speed_kmh_data.push(spd);
+                    accel_mss_data.push(acc);
+                }
+
+                pb.inc(1);
+            }
+
+            scheduler::EventKind::Random(kind) => {
+                let t = event.time;
+                let kind_str: &'static str = match kind {
+                    scheduler::RandomEventKind::Departure          => "departure",
+                    scheduler::RandomEventKind::Arrival            => "arrival",
+                    scheduler::RandomEventKind::SignalChange        => "signal_change",
+                    scheduler::RandomEventKind::SpeedChange { .. } => "speed_change",
+                };
+                // Advance the targeted train to this event's time and record its state.
+                if let Some(scheduler::EntityRef::Train(i)) = event.target {
+                    if i < trains.len() {
+                        let dt_i = t - last_times[i];
+                        if dt_i > 0.0 {
+                            let (pos, spd, acc) = match (&trains[i], &mut states[i]) {
+                                (TrainConfig::Physics { train, environment, driver, .. }, SimState::Physics(s)) => {
+                                    *s = advance_train(s, train, driver, environment, AdvanceTarget::Time(dt_i));
+                                    (Some(s.position.x), Some(s.speed * 3.6), Some(s.acceleration))
+                                }
+                                (TrainConfig::Timing { .. }, SimState::Timing(trace)) => {
+                                    (trace.position_at(t), None, None)
+                                }
+                                _ => unreachable!(),
+                            };
+                            last_times[i] = t;
+                            train_id_data.push(train_id_cache[i]);
+                            event_kind_data.push(kind_str);
+                            time_s_data.push(t);
+                            position_m_data.push(pos);
+                            speed_kmh_data.push(spd);
+                            accel_mss_data.push(acc);
+                        }
+                    }
+                }
+                // Signal events don't produce rows yet.
+            }
         }
 
-        if time_s_data.len() >= flush_rows || step + 1 == steps {
-            // Build the train_id column by cycling the cached &str over the accumulated rows.
-            let train_id_col: Vec<&str> = train_id_cache.iter().copied()
-                .cycle()
-                .take(time_s_data.len())
-                .collect();
+        if time_s_data.len() >= flush_rows {
             let n = time_s_data.len();
             let batch = DataFrame::new(
                 n,
                 vec![
-                    Series::new("train_id".into(),         &train_id_col).into(),
+                    Series::new("train_id".into(),         &train_id_data).into(),
+                    Series::new("event_kind".into(),        &event_kind_data).into(),
                     Series::new("time_s".into(),            &time_s_data).into(),
                     Series::new("position_m".into(),        &position_m_data).into(),
                     Series::new("speed_kmh".into(),         &speed_kmh_data).into(),
                     Series::new("acceleration_mss".into(),  &accel_mss_data).into(),
                 ],
             ).unwrap();
-
             writer.write_batch(&batch)
-                .unwrap_or_else(|e| { eprintln!("Write error at step {step}: {e}"); std::process::exit(1) });
+                .unwrap_or_else(|e| { eprintln!("Write error: {e}"); std::process::exit(1) });
             total_rows += n;
             pb.println(format!("  flushed {n} rows (total: {total_rows})"));
-
+            train_id_data.clear();
+            event_kind_data.clear();
             time_s_data.clear();
             position_m_data.clear();
             speed_kmh_data.clear();
             accel_mss_data.clear();
         }
+    }
 
-        pb.inc(1);
+    // Final flush: covers both normal queue exhaustion and the time-limit break.
+    if !time_s_data.is_empty() {
+        let n = time_s_data.len();
+        let batch = DataFrame::new(
+            n,
+            vec![
+                Series::new("train_id".into(),         &train_id_data).into(),
+                Series::new("time_s".into(),            &time_s_data).into(),
+                Series::new("position_m".into(),        &position_m_data).into(),
+                Series::new("speed_kmh".into(),         &speed_kmh_data).into(),
+                Series::new("acceleration_mss".into(),  &accel_mss_data).into(),
+            ],
+        ).unwrap();
+        writer.write_batch(&batch)
+            .unwrap_or_else(|e| { eprintln!("Write error (final flush): {e}"); std::process::exit(1) });
+        total_rows += n;
+        pb.println(format!("  flushed {n} rows (total: {total_rows})"));
     }
 
     pb.finish_and_clear();

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,0 +1,124 @@
+#![allow(dead_code)] // placeholder fields will be read once events drive real logic
+
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashSet};
+
+// ---------------------------------------------------------------------------
+// Entity references
+// ---------------------------------------------------------------------------
+
+/// A reference to a simulated entity that can own or be the target of an event.
+/// Add new variants here as infrastructure types are introduced.
+#[derive(Debug, Clone, Copy)]
+pub enum EntityRef {
+    Train(usize),
+    Signal(usize),
+}
+
+// ---------------------------------------------------------------------------
+// Cancellation token
+// ---------------------------------------------------------------------------
+
+/// Opaque handle returned by [`EventQueue::push`], usable to cancel the event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EventId(u64);
+
+// ---------------------------------------------------------------------------
+// Event kinds
+// ---------------------------------------------------------------------------
+
+/// Placeholder random event kinds — no simulation effect yet.
+/// The entity they act on is carried by `Event::target`, not embedded here.
+#[derive(Debug, Clone)]
+pub enum RandomEventKind {
+    Departure,
+    Arrival,
+    SignalChange,
+    SpeedChange { new_speed_kmh: f64 },
+}
+
+#[derive(Debug, Clone)]
+pub enum EventKind {
+    /// Advance physics by one fixed time step.
+    /// Self-scheduling: each tick pushes the next one; the event loop's time
+    /// guard (`event.time > duration`) stops the chain.
+    PhysicsTick,
+    /// Placeholder event targeting an entity — no effect yet.
+    Random(RandomEventKind),
+}
+
+// ---------------------------------------------------------------------------
+// Event
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct Event {
+    pub id: EventId,
+    /// Simulation time (seconds) at which this event fires.
+    pub time: f64,
+    /// The entity this event acts on, if any.
+    pub target: Option<EntityRef>,
+    pub kind: EventKind,
+}
+
+// Min-heap ordering: smaller time → higher priority (via BinaryHeap's max-heap).
+impl PartialEq  for Event { fn eq(&self, other: &Self) -> bool { self.time == other.time } }
+impl Eq         for Event {}
+impl PartialOrd for Event { fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp(other)) } }
+impl Ord for Event {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.time.partial_cmp(&self.time).unwrap_or(Ordering::Equal)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EventQueue
+// ---------------------------------------------------------------------------
+
+/// Priority queue of simulation events ordered by ascending time.
+///
+/// Cancellation is lazy: cancelled events are silently skipped on [`pop`]
+/// rather than being removed from the heap immediately (O(1) cancel, O(log n) pop).
+pub struct EventQueue {
+    heap:      BinaryHeap<Event>,
+    cancelled: HashSet<EventId>,
+    next_id:   u64,
+}
+
+impl EventQueue {
+    pub fn new() -> Self {
+        Self { heap: BinaryHeap::new(), cancelled: HashSet::new(), next_id: 0 }
+    }
+
+    /// Schedule a new event. Returns an [`EventId`] that can be passed to
+    /// [`cancel`] to prevent the event from firing.
+    pub fn push(&mut self, time: f64, target: Option<EntityRef>, kind: EventKind) -> EventId {
+        let id = EventId(self.next_id);
+        self.next_id += 1;
+        self.heap.push(Event { id, time, target, kind });
+        id
+    }
+
+    /// Mark an event as cancelled. It will be silently discarded when it
+    /// reaches the front of the queue. Safe to call on an already-fired or
+    /// already-cancelled event (no-op in both cases).
+    pub fn cancel(&mut self, id: EventId) {
+        self.cancelled.insert(id);
+    }
+
+    /// Pop and return the earliest non-cancelled event, or `None` if the
+    /// queue is empty (or contains only cancelled events).
+    pub fn pop(&mut self) -> Option<Event> {
+        loop {
+            let event = self.heap.pop()?;
+            // `remove` returns true if the id was present → event is cancelled.
+            if !self.cancelled.remove(&event.id) {
+                return Some(event);
+            }
+            // Cancelled — discard and try the next one.
+        }
+    }
+
+    pub fn len(&self) -> usize       { self.heap.len() }
+    pub fn is_empty(&self) -> bool   { self.heap.is_empty() }
+}


### PR DESCRIPTION
## Summary

- **New `src/scheduler.rs`**: `EventQueue` (min-heap via `BinaryHeap`), `Event` with `EventId` for lazy O(1) cancellation, `EntityRef` (`Train`/`Signal`) so events carry their target entity, and `EventKind` with `PhysicsTick` (self-scheduling) and typed `Random` placeholder variants.
- **Event-driven main loop**: the `for step in 0..steps` loop is replaced by a `while let Some(event) = queue.pop()` loop with a hard time-bound break (`event.time > duration`). `PhysicsTick` self-schedules its successor only when `t + dt <= duration` and trains are still moving or other events are pending — avoiding wasted ticks when everything is at a standstill.
- **Per-train `last_times` tracking**: each train records the last simulation time it was advanced. Random events advance only their target train to the event time and record a snapshot; the next `PhysicsTick` advances each train from its individual `last_times[i]`, keeping state consistent across mixed-source events.
- **`event_kind` column in Parquet output**: every output row is tagged (`"physics_tick"`, `"departure"`, `"arrival"`, `"speed_change"`) so downstream analysis can distinguish regular ticks from event-triggered snapshots.
- **`rand = "0.8"` dependency** for random placeholder event seeding; `config_physics.yaml` bumped to `time_step_s: 30.0` to demonstrate large-step DES with intra-step random snapshots.

## Test plan

- [ ] `cargo build` passes with only the pre-existing `step_trains` dead-code warning
- [ ] `cargo test` passes (physics unit tests unchanged)
- [ ] `cargo run --release -- config/config_physics.yaml /tmp/out.parquet` produces ~132 + N rows where N varies per run (random events)
- [ ] Parquet output contains `event_kind` column with values `physics_tick` / `departure` / `arrival` / `speed_change`
- [ ] Simulation terminates cleanly when all trains reach standstill before `duration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)