### PR TITLE
Fix missing event_kind in final Parquet flush (#14) and rename break_ratio to brake_ratio (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ simulation:
         wind_speed: 0.0   # m/s (head-wind positive)
       driver:
         power_ratio: 0.8  # 0–1 throttle
-        break_ratio: 0.0  # 0–1 braking
+        brake_ratio: 0.0  # 0–1 braking
 ```
 
 ### Timing trains (`kind: timing`)

--- a/config/config_mixed.yaml
+++ b/config/config_mixed.yaml
@@ -18,7 +18,7 @@ simulation:
         wind_speed: 0.0                     # m/s (head-wind positive)
       driver:
         power_ratio: 0.8                    # 0–1 throttle
-        break_ratio: 0.0                    # 0–1 braking
+        brake_ratio: 0.0                    # 0–1 braking
 
     # Timing trains — positions interpolated from real berth timing data.
     # Timestamps are normalised to t=0 at the first record.

--- a/config/config_physics.yaml
+++ b/config/config_physics.yaml
@@ -17,7 +17,7 @@ simulation:
         wind_speed: 0.0                     # m/s (head-wind positive)
       driver:
         power_ratio: 0.8                    # 0–1 throttle
-        break_ratio: 0.0                    # 0–1 braking
+        brake_ratio: 0.0                    # 0–1 braking
 
     - id: "train_2"
       kind: physics
@@ -33,4 +33,4 @@ simulation:
         wind_speed: 5.0                     # m/s head-wind
       driver:
         power_ratio: 1.0
-        break_ratio: 0.0
+        brake_ratio: 0.0

--- a/python/rusty_trains/run_100trains.py
+++ b/python/rusty_trains/run_100trains.py
@@ -51,7 +51,7 @@ def make_train(index: int, rng: random.Random) -> dict:
         },
         "driver": {
             "power_ratio": round(r(*p["power_ratio"]), 2),
-            "break_ratio": 0.0,
+            "brake_ratio": 0.0,
         },
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,29 @@ enum SimState {
 ///                        is outside its data range)
 /// - `speed_kmh`        — speed in km/h (null for timing trains)
 /// - `acceleration_mss` — acceleration in m/s² (null for timing trains)
+
+fn build_batch<'a>(
+    train_id_data:   &[&'a str],
+    event_kind_data: &[&'a str],
+    time_s_data:     &[f64],
+    position_m_data: &[Option<f64>],
+    speed_kmh_data:  &[Option<f64>],
+    accel_mss_data:  &[Option<f64>],
+) -> DataFrame {
+    let n = time_s_data.len();
+    DataFrame::new(
+        n,
+        vec![
+            Series::new("train_id".into(),         train_id_data).into(),
+            Series::new("event_kind".into(),        event_kind_data).into(),
+            Series::new("time_s".into(),            time_s_data).into(),
+            Series::new("position_m".into(),        position_m_data).into(),
+            Series::new("speed_kmh".into(),         speed_kmh_data).into(),
+            Series::new("acceleration_mss".into(),  accel_mss_data).into(),
+        ],
+    ).unwrap()
+}
+
 fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::path::Path, flush_rows: usize) {
     let steps = (duration / dt).round() as usize;
     let buf_cap = flush_rows.min(steps * trains.len());
@@ -333,17 +356,7 @@ fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::
 
         if time_s_data.len() >= flush_rows {
             let n = time_s_data.len();
-            let batch = DataFrame::new(
-                n,
-                vec![
-                    Series::new("train_id".into(),          &train_id_data).into(),
-                    Series::new("event_kind".into(),        &event_kind_data).into(),
-                    Series::new("time_s".into(),            &time_s_data).into(),
-                    Series::new("position_m".into(),        &position_m_data).into(),
-                    Series::new("speed_kmh".into(),         &speed_kmh_data).into(),
-                    Series::new("acceleration_mss".into(),  &accel_mss_data).into(),
-                ],
-            ).unwrap();
+            let batch = build_batch(&train_id_data, &event_kind_data, &time_s_data, &position_m_data, &speed_kmh_data, &accel_mss_data);
             writer.write_batch(&batch)
                 .unwrap_or_else(|e| { eprintln!("Write error: {e}"); std::process::exit(1) });
             total_rows += n;
@@ -360,17 +373,7 @@ fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::
     // Final flush: covers both normal queue exhaustion and the time-limit break.
     if !time_s_data.is_empty() {
         let n = time_s_data.len();
-        let batch = DataFrame::new(
-            n,
-            vec![
-                Series::new("train_id".into(),          &train_id_data).into(),
-                Series::new("event_kind".into(),        &event_kind_data).into(),
-                Series::new("time_s".into(),            &time_s_data).into(),
-                Series::new("position_m".into(),        &position_m_data).into(),
-                Series::new("speed_kmh".into(),         &speed_kmh_data).into(),
-                Series::new("acceleration_mss".into(),  &accel_mss_data).into(),
-            ],
-        ).unwrap();
+        let batch = build_batch(&train_id_data, &event_kind_data, &time_s_data, &position_m_data, &speed_kmh_data, &accel_mss_data);
         writer.write_batch(&batch)
             .unwrap_or_else(|e| { eprintln!("Write error (final flush): {e}"); std::process::exit(1) });
         total_rows += n;

--- a/src/main.rs
+++ b/src/main.rs
@@ -364,6 +364,7 @@ fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::
             n,
             vec![
                 Series::new("train_id".into(),          &train_id_data).into(),
+                Series::new("event_kind".into(),        &event_kind_data).into(),
                 Series::new("time_s".into(),            &time_s_data).into(),
                 Series::new("position_m".into(),        &position_m_data).into(),
                 Series::new("speed_kmh".into(),         &speed_kmh_data).into(),

--- a/src/model.rs
+++ b/src/model.rs
@@ -14,7 +14,7 @@ pub struct Trajectory {
 
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct DriverInput {
-    pub break_ratio: f64,
+    pub brake_ratio: f64,
     pub power_ratio: f64,
 }
 

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -129,18 +129,18 @@ pub fn advance_train(state: &SimulatedState, params: &TrainDescription, driver: 
 
 pub fn step_trains(state: &SimulatedState, params: &TrainDescription, driver: &DriverInput, env: &Environment, dt: f64) -> SimulatedState {
     let speed = state.speed;
-    let breaking = driver.brake_ratio>0.0;
+    let braking = driver.brake_ratio>0.0;
 
     let low_speed_force = params.traction_force_at_standstill * driver.power_ratio;
     let high_speed_force = if speed > 0.1 { params.power * driver.power_ratio / speed } else { low_speed_force };
 
-    let traction_force = if !breaking {
+    let traction_force = if !braking {
         f64::min(low_speed_force, high_speed_force)
     } else {
         0.0
     };
 
-    let braking_force = if breaking { params.braking_force * driver.brake_ratio } else { 0.0 };
+    let braking_force = if braking { params.braking_force * driver.brake_ratio } else { 0.0 };
     // Gravity component along track (positive = uphill resistance)
     let gravity_force = params.mass * G * env.gradient;
 

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -11,13 +11,13 @@ pub enum AdvanceTarget {
 
 #[allow(dead_code)]
 fn net_force_at_speed(v: f64, params: &TrainDescription, driver: &DriverInput, env: &Environment) -> f64 {
-    let braking = driver.break_ratio > 0.0;
+    let braking = driver.brake_ratio > 0.0;
 
     let low_speed_force = params.traction_force_at_standstill * driver.power_ratio;
     let high_speed_force = if v > 0.1 { params.power * driver.power_ratio / v } else { low_speed_force };
 
     let traction_force = if !braking { f64::min(low_speed_force, high_speed_force) } else { 0.0 };
-    let braking_force  = if  braking { params.braking_force * driver.break_ratio    } else { 0.0 };
+    let braking_force  = if  braking { params.braking_force * driver.brake_ratio    } else { 0.0 };
 
     let gravity_force      = params.mass * G * env.gradient;
     let drag_force         = params.drag_coeff * (v + env.wind_speed).powi(2);
@@ -79,7 +79,7 @@ pub fn advance_train(state: &SimulatedState, params: &TrainDescription, driver: 
             } else if a < 0.0 {
                 // When coasting above equilibrium (no brakes), cap deceleration at v_eq
                 // to prevent undershooting.  When braking there is no equilibrium above 0.
-                let v_floor = if driver.break_ratio == 0.0 {
+                let v_floor = if driver.brake_ratio == 0.0 {
                     terminal_speed(0.0, v0, params, driver, env).unwrap_or(0.0)
                 } else {
                     0.0
@@ -129,7 +129,7 @@ pub fn advance_train(state: &SimulatedState, params: &TrainDescription, driver: 
 
 pub fn step_trains(state: &SimulatedState, params: &TrainDescription, driver: &DriverInput, env: &Environment, dt: f64) -> SimulatedState {
     let speed = state.speed;
-    let breaking = driver.break_ratio>0.0;
+    let breaking = driver.brake_ratio>0.0;
 
     let low_speed_force = params.traction_force_at_standstill * driver.power_ratio;
     let high_speed_force = if speed > 0.1 { params.power * driver.power_ratio / speed } else { low_speed_force };
@@ -140,7 +140,7 @@ pub fn step_trains(state: &SimulatedState, params: &TrainDescription, driver: &D
         0.0
     };
 
-    let braking_force = if breaking { params.braking_force * driver.break_ratio } else { 0.0 };
+    let braking_force = if breaking { params.braking_force * driver.brake_ratio } else { 0.0 };
     // Gravity component along track (positive = uphill resistance)
     let gravity_force = params.mass * G * env.gradient;
 
@@ -213,7 +213,7 @@ mod tests {
     #[test]
     fn test_accelerating_from_standstill() {
         let p = test_params();
-        let d = DriverInput { power_ratio: 0.8, break_ratio: 0.0 };
+        let d = DriverInput { power_ratio: 0.8, brake_ratio: 0.0 };
         let e = Environment { gradient: 0.0, wind_speed: 0.0 };
         let s0 = initial_state(0.0);
         assert_within("standstill",
@@ -224,7 +224,7 @@ mod tests {
     #[test]
     fn test_accelerating_from_standstill_distance() {
         let p = test_params();
-        let d = DriverInput { power_ratio: 0.8, break_ratio: 0.0 };
+        let d = DriverInput { power_ratio: 0.8, brake_ratio: 0.0 };
         let e = Environment { gradient: 0.0, wind_speed: 0.0 };
         let s0 = initial_state(0.0);
         let reference = step_reference(&s0, &p, &d, &e, 10.0);
@@ -236,7 +236,7 @@ mod tests {
     #[test]
     fn test_braking() {
         let p = test_params();
-        let d = DriverInput { power_ratio: 0.0, break_ratio: 0.5 };
+        let d = DriverInput { power_ratio: 0.0, brake_ratio: 0.5 };
         let e = Environment { gradient: 0.0, wind_speed: 0.0 };
         let s0 = initial_state(20.0); // 72 km/h
         assert_within("braking",
@@ -247,7 +247,7 @@ mod tests {
     #[test]
     fn test_braking_distance() {
         let p = test_params();
-        let d = DriverInput { power_ratio: 0.0, break_ratio: 0.5 };
+        let d = DriverInput { power_ratio: 0.0, brake_ratio: 0.5 };
         let e = Environment { gradient: 0.0, wind_speed: 0.0 };
         let s0 = initial_state(20.0);
         let reference = step_reference(&s0, &p, &d, &e, 10.0);
@@ -259,7 +259,7 @@ mod tests {
     #[test]
     fn test_positive_gradient() {
         let p = test_params();
-        let d = DriverInput { power_ratio: 0.8, break_ratio: 0.0 };
+        let d = DriverInput { power_ratio: 0.8, brake_ratio: 0.0 };
         let e = Environment { gradient: 0.02, wind_speed: 0.0 }; // 2% uphill
         let s0 = initial_state(10.0);
         assert_within("positive gradient",
@@ -270,7 +270,7 @@ mod tests {
     #[test]
     fn test_positive_gradient_distance() {
         let p = test_params();
-        let d = DriverInput { power_ratio: 0.8, break_ratio: 0.0 };
+        let d = DriverInput { power_ratio: 0.8, brake_ratio: 0.0 };
         let e = Environment { gradient: 0.02, wind_speed: 0.0 };
         let s0 = initial_state(10.0);
         let reference = step_reference(&s0, &p, &d, &e, 10.0);
@@ -282,7 +282,7 @@ mod tests {
     #[test]
     fn test_negative_gradient() {
         let p = test_params();
-        let d = DriverInput { power_ratio: 0.8, break_ratio: 0.0 };
+        let d = DriverInput { power_ratio: 0.8, brake_ratio: 0.0 };
         let e = Environment { gradient: -0.02, wind_speed: 0.0 }; // 2% downhill
         let s0 = initial_state(10.0);
         assert_within("negative gradient",
@@ -293,7 +293,7 @@ mod tests {
     #[test]
     fn test_negative_gradient_distance() {
         let p = test_params();
-        let d = DriverInput { power_ratio: 0.8, break_ratio: 0.0 };
+        let d = DriverInput { power_ratio: 0.8, brake_ratio: 0.0 };
         let e = Environment { gradient: -0.02, wind_speed: 0.0 };
         let s0 = initial_state(10.0);
         let reference = step_reference(&s0, &p, &d, &e, 10.0);


### PR DESCRIPTION
## Summary

- **Fixes #14**: The final flush in `run_simulation` ([main.rs:363-376](src/main.rs#L363)) was missing the `event_kind` column, causing a schema mismatch with the mid-loop flush (which includes 6 columns). Added the missing `Series::new("event_kind"...)` line.
- **Fixes #15**: Renamed `DriverInput::break_ratio` → `brake_ratio` everywhere — `model.rs`, `physics.rs`, `config/*.yaml`, `scripts/run_100trains.py`, and `README.md`.

## Test plan

- [x] `cargo test` — all 8 physics tests pass
- [x] No remaining `break_ratio` occurrences in the codebase
- [x] Both mid-loop and final-flush `DataFrame::new` calls now have identical 6-column schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)