### PR TITLE
Extract flush_batch helper to deduplicate Parquet flush logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ license = "MIT"
 
 [dependencies]
 polars       = { version = "0.53", features = ["parquet"] }
-polars-io    = { version = "0.53", features = ["parquet"] }
 serde        = { version = "1",    features = ["derive"] }
 serde_yaml_ng = "0.9"
 clap         = { version = "4",    features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 
 [dependencies]
 polars       = { version = "0.53", features = ["parquet"] }
+polars-io    = { version = "0.53", features = ["parquet"] }
 serde        = { version = "1",    features = ["derive"] }
 serde_yaml_ng = "0.9"
 clap         = { version = "4",    features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,7 @@ fn build_batch<'a>(
 /// Write buffered rows to the Parquet file and clear the buffers.
 /// Extracted to avoid duplicating the flush logic between the mid-loop check and the final flush.
 fn flush_batch<W: std::io::Write>(
-    writer:          &mut polars_io::parquet::write::BatchedWriter<W>,
+    writer:          &mut polars::io::parquet::write::BatchedWriter<W>,
     train_id_data:   &mut Vec<&str>,
     event_kind_data: &mut Vec<&'static str>,
     time_s_data:     &mut Vec<f64>,
@@ -162,11 +162,12 @@ fn flush_batch<W: std::io::Write>(
     accel_mss_data:  &mut Vec<Option<f64>>,
     total_rows:      &mut usize,
     pb:              &ProgressBar,
+    label:           &str,
 ) {
     let n = time_s_data.len();
     let batch = build_batch(train_id_data, event_kind_data, time_s_data, position_m_data, speed_kmh_data, accel_mss_data);
     writer.write_batch(&batch)
-        .unwrap_or_else(|e| { eprintln!("Write error: {e}"); std::process::exit(1) });
+        .unwrap_or_else(|e| { eprintln!("Write error ({label}): {e}"); std::process::exit(1) });
     *total_rows += n;
     pb.println(format!("  flushed {n} rows (total: {total_rows})"));
     train_id_data.clear();
@@ -382,13 +383,23 @@ fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::
         }
 
         if time_s_data.len() >= flush_rows {
-            flush_batch(&mut writer, &mut train_id_data, &mut event_kind_data, &mut time_s_data, &mut position_m_data, &mut speed_kmh_data, &mut accel_mss_data, &mut total_rows, &pb);
+            flush_batch(
+                &mut writer,
+                &mut train_id_data, &mut event_kind_data,
+                &mut time_s_data, &mut position_m_data, &mut speed_kmh_data, &mut accel_mss_data,
+                &mut total_rows, &pb, "mid-loop",
+            );
         }
     }
 
     // Final flush: covers both normal queue exhaustion and the time-limit break.
     if !time_s_data.is_empty() {
-        flush_batch(&mut writer, &mut train_id_data, &mut event_kind_data, &mut time_s_data, &mut position_m_data, &mut speed_kmh_data, &mut accel_mss_data, &mut total_rows, &pb);
+        flush_batch(
+            &mut writer,
+            &mut train_id_data, &mut event_kind_data,
+            &mut time_s_data, &mut position_m_data, &mut speed_kmh_data, &mut accel_mss_data,
+            &mut total_rows, &pb, "final flush",
+        );
     }
 
     pb.finish_and_clear();

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,33 @@ fn build_batch<'a>(
     ).unwrap()
 }
 
+/// Write buffered rows to the Parquet file and clear the buffers.
+/// Extracted to avoid duplicating the flush logic between the mid-loop check and the final flush.
+fn flush_batch<W: std::io::Write>(
+    writer:          &mut polars_io::parquet::write::BatchedWriter<W>,
+    train_id_data:   &mut Vec<&str>,
+    event_kind_data: &mut Vec<&'static str>,
+    time_s_data:     &mut Vec<f64>,
+    position_m_data: &mut Vec<Option<f64>>,
+    speed_kmh_data:  &mut Vec<Option<f64>>,
+    accel_mss_data:  &mut Vec<Option<f64>>,
+    total_rows:      &mut usize,
+    pb:              &ProgressBar,
+) {
+    let n = time_s_data.len();
+    let batch = build_batch(train_id_data, event_kind_data, time_s_data, position_m_data, speed_kmh_data, accel_mss_data);
+    writer.write_batch(&batch)
+        .unwrap_or_else(|e| { eprintln!("Write error: {e}"); std::process::exit(1) });
+    *total_rows += n;
+    pb.println(format!("  flushed {n} rows (total: {total_rows})"));
+    train_id_data.clear();
+    event_kind_data.clear();
+    time_s_data.clear();
+    position_m_data.clear();
+    speed_kmh_data.clear();
+    accel_mss_data.clear();
+}
+
 fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::path::Path, flush_rows: usize) {
     let steps = (duration / dt).round() as usize;
     let buf_cap = flush_rows.min(steps * trains.len());
@@ -355,29 +382,13 @@ fn run_simulation(trains: &[TrainConfig], dt: f64, duration: f64, output: &std::
         }
 
         if time_s_data.len() >= flush_rows {
-            let n = time_s_data.len();
-            let batch = build_batch(&train_id_data, &event_kind_data, &time_s_data, &position_m_data, &speed_kmh_data, &accel_mss_data);
-            writer.write_batch(&batch)
-                .unwrap_or_else(|e| { eprintln!("Write error: {e}"); std::process::exit(1) });
-            total_rows += n;
-            pb.println(format!("  flushed {n} rows (total: {total_rows})"));
-            train_id_data.clear();
-            event_kind_data.clear();
-            time_s_data.clear();
-            position_m_data.clear();
-            speed_kmh_data.clear();
-            accel_mss_data.clear();
+            flush_batch(&mut writer, &mut train_id_data, &mut event_kind_data, &mut time_s_data, &mut position_m_data, &mut speed_kmh_data, &mut accel_mss_data, &mut total_rows, &pb);
         }
     }
 
     // Final flush: covers both normal queue exhaustion and the time-limit break.
     if !time_s_data.is_empty() {
-        let n = time_s_data.len();
-        let batch = build_batch(&train_id_data, &event_kind_data, &time_s_data, &position_m_data, &speed_kmh_data, &accel_mss_data);
-        writer.write_batch(&batch)
-            .unwrap_or_else(|e| { eprintln!("Write error (final flush): {e}"); std::process::exit(1) });
-        total_rows += n;
-        pb.println(format!("  flushed {n} rows (total: {total_rows})"));
+        flush_batch(&mut writer, &mut train_id_data, &mut event_kind_data, &mut time_s_data, &mut position_m_data, &mut speed_kmh_data, &mut accel_mss_data, &mut total_rows, &pb);
     }
 
     pb.finish_and_clear();


### PR DESCRIPTION
## Summary

- Extracts a `flush_batch` helper from the two near-identical flush blocks in `run_simulation` (mid-loop threshold check and final flush)
- Adds `polars-io` as a direct dependency to name the `BatchedWriter<W>` type in the helper signature
- Both call sites now delegate to the single helper, eliminating the risk of the two paths diverging

Closes #16

## Test plan
- [ ] `cargo build --release` passes with no new warnings
- [ ] Run with a mixed config and verify Parquet output is identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)