### PR TITLE
Deduplicate PowerMode/TrainTractionMode and DrivingResistance/TrainDrivingResistance

### DIFF
--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -3,7 +3,6 @@ description: Take an issue from Github and start a task to fix it
 argument-hint: [issue number]
 ---
 ## Fix issue
-## Fix issue
 1. If an issue number is provided (`$ARGUMENTS`), fix that specific issue. Otherwise, list open issues and pick one.
 2. Run `/start-task`
 3. Work on it

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,8 +1,9 @@
 ---
 description: Take an issue from Github and start a task to fix it
+argument-hint: [issue number]
 ---
 ## Fix issue
-1. List the open issues on GitHub
-2. Pick one to fix
-3. Initial `/start-task`
-4. Work on it
+## Fix issue
+1. If an issue number is provided (`$ARGUMENTS`), fix that specific issue. Otherwise, list open issues and pick one.
+2. Run `/start-task`
+3. Work on it

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -6,3 +6,4 @@ argument-hint: [issue number]
 1. If an issue number is provided (`$ARGUMENTS`), fix that specific issue. Otherwise, list open issues and pick one.
 2. Run `/start-task`
 3. Work on it
+4. Make sure you reference the issue in the PR description

--- a/python/hs_trains/model/rollingstock.py
+++ b/python/hs_trains/model/rollingstock.py
@@ -201,22 +201,22 @@ class DrivingResistanceDetails(_Base, tag="details", ns=_NS):
     value_table: Optional[ValueTable] = element(tag="valueTable", ns=_NS, default=None)
 
 
-class DrivingResistance(_Base, tag="drivingResistance", ns=_NS):
+class _DrivingResistanceBase(_Base):
+    """Shared fields for vehicle- and formation-level driving resistance."""
+
+    tunnel_factor: Optional[Decimal] = attr(name="tunnelFactor", default=None,
+        description="Multiplier applied to driving resistance when travelling through a tunnel.")
+    info: Optional[DrivingResistanceInfo] = element(tag="info", ns=_NS, default=None)
+    details: Optional[DrivingResistanceDetails] = element(tag="details", ns=_NS, default=None)
+
+
+class DrivingResistance(_DrivingResistanceBase, tag="drivingResistance", ns=_NS):
     """Sum of resistances a vehicle must overcome to travel at constant or accelerated speed."""
 
-    tunnel_factor: Optional[Decimal] = attr(name="tunnelFactor", default=None,
-        description="Multiplier applied to driving resistance when travelling through a tunnel.")
-    info: Optional[DrivingResistanceInfo] = element(tag="info", ns=_NS, default=None)
-    details: Optional[DrivingResistanceDetails] = element(tag="details", ns=_NS, default=None)
 
-
-class TrainDrivingResistance(_Base, tag="trainResistance", ns=_NS):
+class TrainDrivingResistance(_DrivingResistanceBase, tag="trainResistance", ns=_NS):
     """Formation-level driving resistance, adds Davies formula factors."""
 
-    tunnel_factor: Optional[Decimal] = attr(name="tunnelFactor", default=None,
-        description="Multiplier applied to driving resistance when travelling through a tunnel.")
-    info: Optional[DrivingResistanceInfo] = element(tag="info", ns=_NS, default=None)
-    details: Optional[DrivingResistanceDetails] = element(tag="details", ns=_NS, default=None)
     davies_formula_factors: Optional[DaviesFormula] = element(
         tag="daviesFormulaFactors", ns=_NS, default=None
     )
@@ -247,16 +247,20 @@ class TractionData(_Base, tag="tractionData", ns=_NS):
     details: Optional[TractionDetails] = element(tag="details", ns=_NS, default=None)
 
 
-class PowerMode(_Base, tag="powerMode", ns=_NS):
+class _TractionModeBase(_Base):
+    """Shared fields for vehicle- and formation-level traction modes."""
+
     mode: Literal["diesel", "electric", "battery"] = attr(name="mode")
     is_primary_mode: XmlBool = attr(name="isPrimaryMode", default=True)
     traction_data: Optional[TractionData] = element(tag="tractionData", ns=_NS, default=None)
 
 
-class TrainTractionMode(_Base, tag="tractionMode", ns=_NS):
-    mode: Literal["diesel", "electric", "battery"] = attr(name="mode")
-    is_primary_mode: XmlBool = attr(name="isPrimaryMode", default=True)
-    traction_data: Optional[TractionData] = element(tag="tractionData", ns=_NS, default=None)
+class PowerMode(_TractionModeBase, tag="powerMode", ns=_NS):
+    """Traction mode for a single vehicle."""
+
+
+class TrainTractionMode(_TractionModeBase, tag="tractionMode", ns=_NS):
+    """Traction mode for a formation."""
 
 
 class Engine(_Base, tag="engine", ns=_NS):

--- a/python/tests/test_rollingstock.py
+++ b/python/tests/test_rollingstock.py
@@ -249,7 +249,70 @@ class TestTrainDrivingResistance:
             )
         )
         el = _xml(tr)
-        assert el.find(_clark("info")) is not None
+        info = el.find(_clark("info"))
+        assert info is not None
+        assert info.get("airDragCoefficient") == "0.7"
+        assert info.get("crossSectionArea") == "10.0"
+        assert info.get("rollingResistance") == "1.0"
+
+    def test_round_trip(self):
+        original = TrainDrivingResistance(
+            tunnel_factor=Decimal("1.3"),
+            davies_formula_factors=DaviesFormula(
+                constant_factor_a=Decimal("3800"),
+                speed_dependent_factor_b=Decimal("45"),
+                square_speed_dependent_factor_c=Decimal("2.5"),
+            ),
+        )
+        xml_str = original.to_xml(encoding="unicode", exclude_none=True)
+        restored = TrainDrivingResistance.from_xml(xml_str)
+        assert restored.tunnel_factor == Decimal("1.3")
+        assert restored.davies_formula_factors.constant_factor_a == Decimal("3800")
+
+
+class TestDrivingResistanceRoundTrip:
+    def test_round_trip(self):
+        original = DrivingResistance(tunnel_factor=Decimal("1.1"))
+        xml_str = original.to_xml(encoding="unicode", exclude_none=True)
+        restored = DrivingResistance.from_xml(xml_str)
+        assert restored.tunnel_factor == Decimal("1.1")
+
+
+# ---------------------------------------------------------------------------
+# PowerMode / TrainTractionMode
+# ---------------------------------------------------------------------------
+
+
+class TestPowerMode:
+    def test_xml_tag(self):
+        el = _xml(PowerMode(mode="electric"))
+        assert el.tag == _clark("powerMode")
+
+    def test_shared_fields(self):
+        # mode and isPrimaryMode come from the shared base.
+        pm = PowerMode(mode="battery", is_primary_mode=False)
+        el = _xml(pm)
+        assert el.get("mode") == "battery"
+        assert el.get("isPrimaryMode") == "false"
+
+
+class TestTrainTractionMode:
+    def test_xml_tag(self):
+        el = _xml(TrainTractionMode(mode="diesel"))
+        assert el.tag == _clark("tractionMode")
+
+    def test_shared_fields(self):
+        tm = TrainTractionMode(mode="electric", is_primary_mode=False)
+        el = _xml(tm)
+        assert el.get("mode") == "electric"
+        assert el.get("isPrimaryMode") == "false"
+
+    def test_round_trip(self):
+        original = TrainTractionMode(mode="diesel", is_primary_mode=True)
+        xml_str = original.to_xml(encoding="unicode", exclude_none=True)
+        restored = TrainTractionMode.from_xml(xml_str)
+        assert restored.mode == "diesel"
+        assert restored.is_primary_mode is True
 
 
 # ---------------------------------------------------------------------------
@@ -383,34 +446,6 @@ class TestFormation:
         tm = el.find(_clark("tractionMode"))
         assert tm is not None
         assert tm.get("mode") == "diesel"
-
-    def test_power_mode_xml_tag(self):
-        el = _xml(PowerMode(mode="electric"))
-        assert el.tag == _clark("powerMode")
-
-    def test_train_traction_mode_xml_tag(self):
-        el = _xml(TrainTractionMode(mode="diesel"))
-        assert el.tag == _clark("tractionMode")
-
-    def test_power_mode_shared_fields(self):
-        # mode and isPrimaryMode come from the shared base.
-        pm = PowerMode(mode="battery", is_primary_mode=False)
-        el = _xml(pm)
-        assert el.get("mode") == "battery"
-        assert el.get("isPrimaryMode") == "false"
-
-    def test_train_traction_mode_shared_fields(self):
-        tm = TrainTractionMode(mode="electric", is_primary_mode=False)
-        el = _xml(tm)
-        assert el.get("mode") == "electric"
-        assert el.get("isPrimaryMode") == "false"
-
-    def test_train_traction_mode_round_trip(self):
-        original = TrainTractionMode(mode="diesel", is_primary_mode=True)
-        xml_str = original.to_xml(encoding="unicode", exclude_none=True)
-        restored = TrainTractionMode.from_xml(xml_str)
-        assert restored.mode == "diesel"
-        assert restored.is_primary_mode is True
 
     def test_train_resistance_davies_formula(self):
         tr = TrainDrivingResistance(

--- a/python/tests/test_rollingstock.py
+++ b/python/tests/test_rollingstock.py
@@ -188,6 +188,10 @@ class TestDaviesFormula:
 
 
 class TestDrivingResistance:
+    def test_xml_tag(self):
+        el = _xml(DrivingResistance())
+        assert el.tag == _clark("drivingResistance")
+
     def test_tunnel_factor_omitted_when_none(self):
         dr = DrivingResistance(
             info=DrivingResistanceInfo(
@@ -200,9 +204,7 @@ class TestDrivingResistance:
         assert el.get("tunnelFactor") is None
 
     def test_tunnel_factor_present(self):
-        dr = DrivingResistance(
-            tunnel_factor=Decimal("1.5"),
-        )
+        dr = DrivingResistance(tunnel_factor=Decimal("1.5"))
         el = _xml(dr)
         assert el.get("tunnelFactor") == "1.5"
 
@@ -220,6 +222,34 @@ class TestDrivingResistance:
         assert info.get("airDragCoefficient") == "0.8"
         assert info.get("crossSectionArea") == "9.0"
         assert info.get("rollingResistance") == "1.2"
+
+    def test_no_davies_formula_field(self):
+        # DrivingResistance must not expose daviesFormulaFactors — that belongs
+        # only to TrainDrivingResistance.
+        assert not hasattr(DrivingResistance(), "davies_formula_factors")
+
+
+class TestTrainDrivingResistance:
+    def test_xml_tag(self):
+        el = _xml(TrainDrivingResistance())
+        assert el.tag == _clark("trainResistance")
+
+    def test_inherited_tunnel_factor(self):
+        # tunnel_factor comes from the shared base — verify it serialises correctly.
+        tr = TrainDrivingResistance(tunnel_factor=Decimal("2.1"))
+        el = _xml(tr)
+        assert el.get("tunnelFactor") == "2.1"
+
+    def test_inherited_info_child(self):
+        tr = TrainDrivingResistance(
+            info=DrivingResistanceInfo(
+                air_drag_coefficient=Decimal("0.7"),
+                cross_section_area=Decimal("10.0"),
+                rolling_resistance=Decimal("1.0"),
+            )
+        )
+        el = _xml(tr)
+        assert el.find(_clark("info")) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -353,6 +383,34 @@ class TestFormation:
         tm = el.find(_clark("tractionMode"))
         assert tm is not None
         assert tm.get("mode") == "diesel"
+
+    def test_power_mode_xml_tag(self):
+        el = _xml(PowerMode(mode="electric"))
+        assert el.tag == _clark("powerMode")
+
+    def test_train_traction_mode_xml_tag(self):
+        el = _xml(TrainTractionMode(mode="diesel"))
+        assert el.tag == _clark("tractionMode")
+
+    def test_power_mode_shared_fields(self):
+        # mode and isPrimaryMode come from the shared base.
+        pm = PowerMode(mode="battery", is_primary_mode=False)
+        el = _xml(pm)
+        assert el.get("mode") == "battery"
+        assert el.get("isPrimaryMode") == "false"
+
+    def test_train_traction_mode_shared_fields(self):
+        tm = TrainTractionMode(mode="electric", is_primary_mode=False)
+        el = _xml(tm)
+        assert el.get("mode") == "electric"
+        assert el.get("isPrimaryMode") == "false"
+
+    def test_train_traction_mode_round_trip(self):
+        original = TrainTractionMode(mode="diesel", is_primary_mode=True)
+        xml_str = original.to_xml(encoding="unicode", exclude_none=True)
+        restored = TrainTractionMode.from_xml(xml_str)
+        assert restored.mode == "diesel"
+        assert restored.is_primary_mode is True
 
     def test_train_resistance_davies_formula(self):
         tr = TrainDrivingResistance(


### PR DESCRIPTION
## Summary

- Introduced `_TractionModeBase` to hold the shared `mode`, `is_primary_mode`, and `traction_data` fields; `PowerMode` and `TrainTractionMode` now inherit from it and differ only in their XML tag.
- Introduced `_DrivingResistanceBase` to hold the shared `tunnel_factor`, `info`, and `details` fields; `DrivingResistance` and `TrainDrivingResistance` now inherit from it, with `TrainDrivingResistance` still adding `davies_formula_factors`.

## Test plan
- [x] `uv run python -c "from hs_trains.model.rollingstock import ..."` imports cleanly
- [x] `cargo test` passes (Rust side unaffected)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)