### PR TITLE
Deduplicate BrakeSystem / FormationBrakeSystem

### DIFF
--- a/python/hs_trains/model/rollingstock.py
+++ b/python/hs_trains/model/rollingstock.py
@@ -93,8 +93,8 @@ class AuxiliaryBrakes(_Base, tag="auxiliaryBrakes", ns=_NS):
     Wb: Optional[XmlBool] = attr(name="Wb", default=None)  # eddy current
 
 
-class BrakeSystem(_Base, tag="vehicleBrakes", ns=_NS):
-    """One brake-system configuration (vehicle or formation level)."""
+class _BrakeSystemBase(_Base):
+    """Shared fields for vehicle- and formation-level brake system configurations."""
 
     auxiliary_brakes: list[AuxiliaryBrakes] = element(
         tag="auxiliaryBrakes", ns=_NS, default_factory=list
@@ -118,6 +118,10 @@ class BrakeSystem(_Base, tag="vehicleBrakes", ns=_NS):
         name="regularBrakePercentage", default=None,
         description="Brake percentage for normal brake operations."
     )
+
+
+class BrakeSystem(_BrakeSystemBase, tag="vehicleBrakes", ns=_NS):
+    """One brake-system configuration (vehicle or formation level)."""
 
 
 # ---------------------------------------------------------------------------
@@ -451,27 +455,8 @@ class FormationDecelerationCurve(_Base, tag="decelerationTable", ns=_NS):
     value_table: ValueTable = element(tag="valueTable", ns=_NS)
 
 
-class FormationBrakeSystem(_Base, tag="trainBrakes", ns=_NS):
+class FormationBrakeSystem(_BrakeSystemBase, tag="trainBrakes", ns=_NS):
     """Formation-level brake system configuration (same fields as BrakeSystem)."""
-
-    auxiliary_brakes: list[AuxiliaryBrakes] = element(
-        tag="auxiliaryBrakes", ns=_NS, default_factory=list
-    )
-    air_brake_application_position: Optional[str] = attr(
-        name="airBrakeApplicationPosition", default=None
-    )
-    brake_type: Optional[str] = attr(name="brakeType", default=None)
-    emergency_brake_mass: Optional[Decimal] = attr(name="emergencyBrakeMass", default=None)
-    emergency_brake_percentage: Optional[Decimal] = attr(
-        name="emergencyBrakePercentage", default=None
-    )
-    load_switch: Optional[str] = attr(name="loadSwitch", default=None)
-    max_deceleration: Optional[Decimal] = attr(name="maxDeceleration", default=None)
-    mean_deceleration: Optional[Decimal] = attr(name="meanDeceleration", default=None)
-    regular_brake_mass: Optional[Decimal] = attr(name="regularBrakeMass", default=None)
-    regular_brake_percentage: Optional[Decimal] = attr(
-        name="regularBrakePercentage", default=None
-    )
 
 
 class Formation(_Base, tag="formation", ns=_NS):

--- a/python/hs_trains/model/rollingstock.py
+++ b/python/hs_trains/model/rollingstock.py
@@ -121,7 +121,7 @@ class _BrakeSystemBase(_Base):
 
 
 class BrakeSystem(_BrakeSystemBase, tag="vehicleBrakes", ns=_NS):
-    """One brake-system configuration (vehicle or formation level)."""
+    """Vehicle-level brake system configuration (tag: vehicleBrakes)."""
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_rollingstock.py
+++ b/python/tests/test_rollingstock.py
@@ -7,6 +7,8 @@ import pytest
 
 from hs_trains.model.rollingstock import (
     NS,
+    AuxiliaryBrakes,
+    BrakeSystem,
     Brakes,
     DaviesFormula,
     DecelerationCurve,
@@ -15,6 +17,7 @@ from hs_trains.model.rollingstock import (
     DrivingResistanceInfo,
     Engine,
     Formation,
+    FormationBrakeSystem,
     Formations,
     PowerMode,
     RailML,
@@ -492,6 +495,72 @@ class TestNamespace:
 
     def test_namespace_uri(self):
         assert NS == "https://www.railml.org/schemas/3.3"
+
+
+# ---------------------------------------------------------------------------
+# BrakeSystem / FormationBrakeSystem
+# ---------------------------------------------------------------------------
+
+
+class TestBrakeSystem:
+    def test_xml_tag(self):
+        el = _xml(BrakeSystem())
+        assert el.tag == _clark("vehicleBrakes")
+
+    def test_shared_fields_serialised(self):
+        # Fields from _BrakeSystemBase must serialise correctly on BrakeSystem.
+        bs = BrakeSystem(
+            brake_type="compressedAirBrake",
+            regular_brake_percentage=Decimal("90"),
+            max_deceleration=Decimal("1.2"),
+        )
+        el = _xml(bs)
+        assert el.get("brakeType") == "compressedAirBrake"
+        assert el.get("regularBrakePercentage") == "90"
+        assert el.get("maxDeceleration") == "1.2"
+
+    def test_round_trip(self):
+        original = BrakeSystem(
+            brake_type="compressedAirBrake",
+            regular_brake_percentage=Decimal("90"),
+            emergency_brake_percentage=Decimal("110"),
+            auxiliary_brakes=[AuxiliaryBrakes(E=True)],
+        )
+        xml_str = original.to_xml(encoding="unicode", exclude_none=True)
+        restored = BrakeSystem.from_xml(xml_str)
+        assert restored.brake_type == "compressedAirBrake"
+        assert restored.regular_brake_percentage == Decimal("90")
+        assert restored.emergency_brake_percentage == Decimal("110")
+        assert len(restored.auxiliary_brakes) == 1
+        assert restored.auxiliary_brakes[0].E is True
+
+
+class TestFormationBrakeSystem:
+    def test_xml_tag(self):
+        el = _xml(FormationBrakeSystem())
+        assert el.tag == _clark("trainBrakes")
+
+    def test_shared_fields_serialised(self):
+        # Same fields as BrakeSystem but under a different XML tag.
+        fbs = FormationBrakeSystem(
+            brake_type="vacuumBrake",
+            mean_deceleration=Decimal("0.9"),
+        )
+        el = _xml(fbs)
+        assert el.get("brakeType") == "vacuumBrake"
+        assert el.get("meanDeceleration") == "0.9"
+
+    def test_round_trip(self):
+        original = FormationBrakeSystem(
+            brake_type="vacuumBrake",
+            regular_brake_mass=Decimal("80"),
+            load_switch="G",
+        )
+        xml_str = original.to_xml(encoding="unicode", exclude_none=True)
+        restored = FormationBrakeSystem.from_xml(xml_str)
+        assert restored.brake_type == "vacuumBrake"
+        assert restored.regular_brake_mass == Decimal("80")
+        assert restored.load_switch == "G"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extract `_BrakeSystemBase` with all 10 shared fields (auxiliary brakes, deceleration, brake mass/percentage, etc.)
- `BrakeSystem` (`vehicleBrakes`) and `FormationBrakeSystem` (`trainBrakes`) now inherit from it, differing only in XML tag
- Removes ~15 lines of verbatim duplication that could silently diverge

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)