### PR TITLE
Add TPS assets to RailML: signals, OPs, and waymark chainage alignment

### DIFF
--- a/python/hs_trains/make_gtcl_railml.py
+++ b/python/hs_trains/make_gtcl_railml.py
@@ -72,7 +72,7 @@ from hs_trains.model.infrastructure import (
 )
 from hs_trains.tps import (
     TPS_XML,
-    _WAYMARKS_SHP,
+    WAYMARKS_SHP,
     build_operational_points,
     build_tps_line_networks,
     build_tps_signals,
@@ -108,8 +108,11 @@ def main() -> None:
         )
     if args.tps and not TPS_XML.exists():
         raise SystemExit(f"TPS XML not found: {TPS_XML}")
-    if args.tps and not _WAYMARKS_SHP.exists():
-        print(f"  [warn] NWR_Waymarks.shp not found at {_WAYMARKS_SHP}; station positions will use raw BNG coords only.")
+    if args.tps and not WAYMARKS_SHP.exists():
+        print(
+            f"  [warn] NWR_Waymarks.shp not found at {WAYMARKS_SHP};"
+            " station positions will use raw BNG coords only."
+        )
 
     # ------------------------------------------------------------------
     # Load layers
@@ -171,8 +174,8 @@ def main() -> None:
         tps = load_tps()
 
         waymark_index = None
-        if _WAYMARKS_SHP.exists():
-            print(f"Building waymark index from {_WAYMARKS_SHP} …")
+        if WAYMARKS_SHP.exists():
+            print(f"Building waymark index from {WAYMARKS_SHP} …")
             waymark_index = build_waymark_index()
             print(f"  {waymark_index.elr_count():,} ELRs indexed")
 

--- a/python/hs_trains/make_gtcl_railml.py
+++ b/python/hs_trains/make_gtcl_railml.py
@@ -17,13 +17,36 @@ Functional nodes are derived from NWR_GTCL_Nodes:
   - valancy ≥ 5 → ``switchIS``   (complex junction)
   - valancy 2  →  through-node; no functional element generated
 
-Limitations: switch branch types, speed limits, signals, electrification,
-platforms, and gradients are not present in the GTCL and are omitted.
+When ``--tps`` is given, the TPS XML (assets/XML_p.xml) is parsed in a single
+streaming pass and three categories of data are added:
+
+  operationalPoints
+      One per TPS station, carrying NR-TIPLOC, NR-STANOX and NR-CRS
+      designators.  These are the named locations referenced by PPTimetable
+      journeys.  The 27 stations with a non-zero BNG coordinate also receive a
+      GML Point geometry in WGS84.
+
+  networks (TPS lines)
+      263 named operational lines (e.g. "Edinburgh-Inverness") added alongside
+      the ELR-based networks from GTCL.  In this TPS export the route→line
+      link is not populated so these networks carry a NR-TPS-Line designator
+      and name only (no netElementRefs).
+
+  signals
+      70 k signals from the TPS signal catalogue, each carrying a
+      NR-Signal-Type designator (e.g. "4-Aspect Colour Light (IECC)") and the
+      interlocking system id.  Position data is absent in this export;
+      signals are positioned as a named catalogue only and will be placed on
+      track once the per-ELR chainage alignment with GTCL is implemented.
+
+Limitations: speed limits and gradients from TPS edges are not yet linked to
+GTCL segments (requires per-ELR chainage alignment, a separate task).
 
 Usage
 -----
     uv run make-gtcl-railml output.xml
     uv run make-gtcl-railml output.xml --elr ECM1 MML1   # subset of lines
+    uv run make-gtcl-railml output.xml --tps              # add all TPS data
 """
 
 import argparse
@@ -47,6 +70,15 @@ from hs_trains.model.infrastructure import (
     RailML,
     Topology,
 )
+from hs_trains.tps import (
+    TPS_XML,
+    _WAYMARKS_SHP,
+    build_operational_points,
+    build_tps_line_networks,
+    build_tps_signals,
+    build_waymark_index,
+    load_tps,
+)
 
 
 def main() -> None:
@@ -61,12 +93,23 @@ def main() -> None:
         help="Only convert segments belonging to these ELRs (e.g. --elr ECM1 MML1)."
         " Omit to convert the entire network (slow, large output).",
     )
+    parser.add_argument(
+        "--tps",
+        action="store_true",
+        help="Parse the TPS XML (single pass) and add: operationalPoints (stations),"
+        " named line networks, and signal catalogue"
+        f" (reads {TPS_XML}; takes ~60 s).",
+    )
     args = parser.parse_args()
 
     if not GPKG.exists():
         raise SystemExit(
             f"GeoPackage not found: {GPKG}\nRun 'uv run network-map' first to verify the asset path."
         )
+    if args.tps and not TPS_XML.exists():
+        raise SystemExit(f"TPS XML not found: {TPS_XML}")
+    if args.tps and not _WAYMARKS_SHP.exists():
+        print(f"  [warn] NWR_Waymarks.shp not found at {_WAYMARKS_SHP}; station positions will use raw BNG coords only.")
 
     # ------------------------------------------------------------------
     # Load layers
@@ -118,6 +161,34 @@ def main() -> None:
     )
 
     # ------------------------------------------------------------------
+    # Optionally load TPS data (single streaming parse)
+    # ------------------------------------------------------------------
+    operational_points = []
+    tps_line_networks: list = []
+    tps_signals: list = []
+    if args.tps:
+        print(f"Loading TPS data from {TPS_XML} …")
+        tps = load_tps()
+
+        waymark_index = None
+        if _WAYMARKS_SHP.exists():
+            print(f"Building waymark index from {_WAYMARKS_SHP} …")
+            waymark_index = build_waymark_index()
+            print(f"  {waymark_index.elr_count():,} ELRs indexed")
+
+        operational_points = build_operational_points(
+            tps.stations,
+            elr_lookup=tps.elr_lookup,
+            waymark_index=waymark_index,
+        )
+        tps_line_networks = build_tps_line_networks(tps.lines)
+        tps_signals = build_tps_signals(tps.signals)
+        coords_count = sum(1 for op in operational_points if op.gml_locations)
+        print(f"  {len(operational_points):,} operational points  ({coords_count} with coordinates)")
+        print(f"  {len(tps_line_networks):,} TPS line networks")
+        print(f"  {len(tps_signals):,} signals")
+
+    # ------------------------------------------------------------------
     # Assemble and serialise
     # ------------------------------------------------------------------
     print("Assembling RailML document …")
@@ -126,7 +197,7 @@ def main() -> None:
             topology=Topology(
                 net_elements=net_elements,
                 net_relations=net_relations,
-                networks=networks,
+                networks=networks + tps_line_networks,
             ),
             functional_infrastructure=FunctionalInfrastructure(
                 tracks=tracks,
@@ -134,6 +205,8 @@ def main() -> None:
                 crossings=crossings,
                 buffer_stops=buffer_stops,
                 borders=borders,
+                signals=tps_signals,
+                operational_points=operational_points,
             ),
         )
     )
@@ -150,13 +223,19 @@ def main() -> None:
 
     size_mb = output.stat().st_size / 1_000_000
     print(f"\nWrote {output}  ({size_mb:.1f} MB)")
-    print(f"  netElements  : {len(net_elements):,}")
-    print(f"  netRelations : {len(net_relations):,}")
-    print(f"  networks     : {len(networks):,}  (ELRs)")
-    print(f"  tracks       : {len(tracks):,}")
-    print(f"  switches     : {len(switches):,}")
-    print(f"  crossings    : {len(crossings):,}")
-    print(f"  bufferStops  : {len(buffer_stops):,}")
+    print(f"  netElements       : {len(net_elements):,}")
+    print(f"  netRelations      : {len(net_relations):,}")
+    print(f"  networks          : {len(networks):,}  (ELRs)")
+    print(f"  tracks            : {len(tracks):,}")
+    print(f"  switches          : {len(switches):,}")
+    print(f"  crossings         : {len(crossings):,}")
+    print(f"  bufferStops       : {len(buffer_stops):,}")
+    if tps_line_networks:
+        print(f"  TPS line networks : {len(tps_line_networks):,}")
+    if tps_signals:
+        print(f"  signals           : {len(tps_signals):,}")
+    if operational_points:
+        print(f"  operationalPoints : {len(operational_points):,}")
 
 
 if __name__ == "__main__":

--- a/python/hs_trains/model/infrastructure.py
+++ b/python/hs_trains/model/infrastructure.py
@@ -251,6 +251,53 @@ class Border(_InfraBase, tag="border", ns=_NS):
 
 
 # ---------------------------------------------------------------------------
+# Functional infrastructure — signals
+# ---------------------------------------------------------------------------
+
+
+class Signal(_InfraBase, tag="signal", ns=_NS):
+    """A lineside signal.
+
+    TPS ``signal`` elements carry a name and interlocking-system type (2-aspect,
+    3-aspect, 4-aspect colour-light, buffer stop, ground position light, etc.)
+    but no positional data in this export — ``kmRegionID`` is always 0 and the
+    ``directed`` child is empty.  Signals are therefore added as a named
+    catalogue with type designators; their track position will be resolved once
+    the per-ELR chainage alignment with GTCL is in place.
+
+    Designators carried:
+      - NR-Signal-Type   the human-readable interlocking system name
+      - NR-Interlocking  the interlocking system id (numeric string)
+    """
+
+    id: str = attr(name="id", default_factory=_make_id)
+    name: Optional[str] = attr(name="name", default=None)
+    is_bumper: bool = attr(name="isBumper", default=False)
+    designators: list[Designator] = element(tag="designator", ns=_NS, default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Functional infrastructure — operational points (stations / timing points)
+# ---------------------------------------------------------------------------
+
+
+class OperationalPoint(_InfraBase, tag="operationalPoint", ns=_NS):
+    """A named location where trains stop, pass, or are timed.
+
+    In TPS these are ``station`` elements keyed by their TIPLOC abbreviation.
+    We carry three NR designators (TIPLOC, STANOX, CRS) and, when the TPS
+    record has a non-zero easting/northing, a GML Point in WGS84.
+    """
+
+    id: str = attr(name="id", default_factory=_make_id)
+    name: Optional[str] = attr(name="name", default=None)
+    designators: list[Designator] = element(tag="designator", ns=_NS, default_factory=list)
+    gml_locations: list[GmlLocation] = element(
+        tag="gmlLocation", ns=_NS, default_factory=list
+    )
+
+
+# ---------------------------------------------------------------------------
 # Functional infrastructure container
 # ---------------------------------------------------------------------------
 
@@ -263,6 +310,10 @@ class FunctionalInfrastructure(_Base, tag="functionalInfrastructure", ns=_NS):
         tag="bufferStop", ns=_NS, default_factory=list
     )
     borders: list[Border] = element(tag="border", ns=_NS, default_factory=list)
+    signals: list[Signal] = element(tag="signal", ns=_NS, default_factory=list)
+    operational_points: list[OperationalPoint] = element(
+        tag="operationalPoint", ns=_NS, default_factory=list
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/python/hs_trains/tps.py
+++ b/python/hs_trains/tps.py
@@ -1,0 +1,486 @@
+"""Helpers for loading and converting TPS (Train Planning System) data to RailML.
+
+The TPS XML (assets/XML_p.xml, ~12 M lines) is always parsed with a single
+streaming ``iterparse`` pass.  Call ``load_tps()`` to obtain a ``TpsData``
+object containing all extracted records; the individual ``load_tps_*``
+functions are thin wrappers kept for backward compatibility.
+
+What is extracted
+-----------------
+stations (``TpsStation``)
+    Named timing points keyed by TIPLOC.  Carry STANOX and CRS identifiers
+    that link to PPTimetable journeys and NR CORPUS.  BNG coordinates are
+    present for a small minority of records.  Where a ``<stationposition>``
+    child element is present the (kmregionid, kmvalue) chainage is extracted
+    and used to interpolate a BNG position via the NR Waymarks index.
+
+lines (``TpsLine``)
+    Named operational lines (e.g. "Edinburgh-Inverness") from TPS ``line``
+    elements.  In this export the route→line link is not populated (all
+    ``route.lineid=0``), so line membership cannot be inferred automatically.
+
+signals (``TpsSignal``)
+    Signal catalogue from TPS ``signal`` elements, enriched with the
+    interlocking-system type name (2-aspect, 3-aspect, 4-aspect colour-light,
+    buffer stop, ground position light, …).  Positional data is absent in
+    this export (``kmRegionID=0``, empty ``directed`` child); signals are
+    therefore added to RailML as a named catalogue only.
+
+elr_lookup (``dict[str, str]``)
+    Mapping of TPS km-region ID → ELR code (e.g. ``"1271"`` → ``"ECM1"``).
+    Built from ``kmregionmasterdesc`` elements.  Used by callers that need to
+    resolve a node's ELR from its ``kmregionid`` attribute.
+
+Geographic coordinates
+----------------------
+TPS stations carry their position in one of two ways:
+
+1. Direct BNG easting/northing attributes on the ``<station>`` element.
+   Most records have 0/0 (unknown); only a small cluster carry real values.
+
+2. A ``<stationposition>`` child element with ``kmregionid`` and ``kmvalue``
+   (in metres along the ELR).  ~5,961 stations have this.  The position is
+   resolved by interpolating between the two nearest NR Waymarks on the same
+   ELR — see ``WaymarkIndex`` and ``build_waymark_index()``.  The waymarks
+   file (NWR_Waymarks.shp) gives BNG points at known mileages along each ELR.
+
+Preference: stationposition interpolation is preferred over raw BNG coords
+because it covers far more stations and is geometrically consistent with the
+GTCL segment network.  Raw BNG coords are used only when no stationposition
+is present.
+
+Chainage unit conversion
+------------------------
+TPS ``kmvalue`` is in metres.  NR Waymarks VALUE is in miles (UNIT='M') for
+nearly all ELRs.  Conversion: ``miles = metres / 1609.344``.
+A small number of ELRs use UNIT='K' (km); for these: ``km = metres / 1000``.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from xml.etree.ElementTree import iterparse
+
+import numpy as np
+from pyproj import Transformer
+
+from hs_trains.model.common import Designator
+from hs_trains.model.infrastructure import (
+    GmlLocation,
+    GmlPoint,
+    GmlPos,
+    Network,
+    OperationalPoint,
+    Signal,
+)
+from hs_trains.model.common import Name
+
+TPS_XML = Path(__file__).parents[2] / "assets" / "XML_p.xml"
+_WAYMARKS_SHP = (
+    Path(__file__).parents[2]
+    / "assets"
+    / "NWR_TrackModel20250210 20250306"
+    / "NWR_Waymarks.shp"
+)
+
+# Reusable BNG → WGS84 transformer (always_xy=True: input is easting/northing,
+# output is lon/lat as required by GML srsName=EPSG:4326).
+_BNG_TO_WGS84 = Transformer.from_crs("EPSG:27700", "EPSG:4326", always_xy=True)
+
+_METRES_PER_MILE = 1609.344
+_METRES_PER_KM = 1000.0
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TpsStation:
+    """Parsed representation of a single TPS <station> element."""
+
+    station_id: str
+    tiploc: str       # abbrev — the NR TIPLOC code
+    stanox: str       # 5-digit NR STANOX (may be empty)
+    crs: str          # 3-letter CRS / NLC code (may be empty)
+    name: str         # longname — human-readable station name
+    # BNG OS grid coordinates in metres from the station element; 0 = unknown.
+    easting_m: int = field(default=0)
+    northing_m: int = field(default=0)
+    # Chainage position from <stationposition> child element.
+    # kmregion_id maps to an ELR via TpsData.elr_lookup.
+    # km_value_m is the distance in metres along that ELR from km=0.
+    # Empty string / 0 means absent.
+    kmregion_id: str = field(default="")
+    km_value_m: int = field(default=0)
+
+    @property
+    def has_coordinates(self) -> bool:
+        return self.easting_m != 0 and self.northing_m != 0
+
+    @property
+    def has_chainage(self) -> bool:
+        return bool(self.kmregion_id) and self.km_value_m != 0
+
+
+@dataclass
+class TpsLine:
+    """Parsed representation of a single TPS <line> element."""
+
+    line_id: str
+    description: str  # e.g. "Edinburgh-Inverness"
+
+
+@dataclass
+class TpsSignal:
+    """Parsed representation of a single TPS <signal> element.
+
+    The interlocking_type is resolved from the <interlockingsystem> lookup
+    during the single parse pass (e.g. "4-Aspect Colour Light (IECC)").
+    Position data is not available in this TPS export.
+    """
+
+    signal_id: str        # internal TPS id attribute
+    name: str             # human-readable signal name (e.g. "SIG: D18")
+    is_bumper: bool
+    interlocking_type: str   # resolved name from interlockingsystem
+    interlocking_sys_id: str  # raw interlockingsysid for cross-reference
+
+
+@dataclass
+class TpsData:
+    """All records extracted from a single streaming parse of the TPS XML."""
+
+    stations: list[TpsStation] = field(default_factory=list)
+    lines: list[TpsLine] = field(default_factory=list)
+    signals: list[TpsSignal] = field(default_factory=list)
+    # kmregionid (str) → ELR code (str), e.g. "1271" → "ECM1"
+    elr_lookup: dict[str, str] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Waymark index — ELR chainage → BNG position
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ELRWaymarks:
+    """Sorted waymark arrays for a single ELR."""
+
+    # VALUE column converted to metres along the ELR.
+    position_m: np.ndarray   # shape (N,), dtype float64, strictly ascending
+    easting: np.ndarray      # BNG easting, shape (N,)
+    northing: np.ndarray     # BNG northing, shape (N,)
+
+
+class WaymarkIndex:
+    """Per-ELR sorted chainage→BNG lookup built from NWR_Waymarks.shp.
+
+    Construct via ``build_waymark_index()``.  Call ``interpolate(elr,
+    km_value_m)`` to get a (easting, northing) BNG pair for any (ELR,
+    chainage) that falls within the waymarks coverage.  Returns None when
+    the ELR is unknown or the chainage is outside the waymarks range.
+    """
+
+    def __init__(self, index: dict[str, _ELRWaymarks]) -> None:
+        self._index = index
+
+    def interpolate(self, elr: str, km_value_m: float) -> tuple[float, float] | None:
+        """Return (easting, northing) BNG for the given ELR + chainage (metres).
+
+        Returns None if the ELR is not in the index or the chainage is
+        outside the coverage of the waymarks for that ELR.
+        """
+        entry = self._index.get(elr)
+        if entry is None:
+            return None
+        pos = entry.position_m
+        if km_value_m < pos[0] or km_value_m > pos[-1]:
+            return None
+        idx = int(np.searchsorted(pos, km_value_m))
+        # Clamp to valid interpolation range (searchsorted can return len(pos))
+        if idx == 0:
+            return float(entry.easting[0]), float(entry.northing[0])
+        if idx >= len(pos):
+            return float(entry.easting[-1]), float(entry.northing[-1])
+        t = (km_value_m - pos[idx - 1]) / (pos[idx] - pos[idx - 1])
+        e = entry.easting[idx - 1] + t * (entry.easting[idx] - entry.easting[idx - 1])
+        n = entry.northing[idx - 1] + t * (entry.northing[idx] - entry.northing[idx - 1])
+        return float(e), float(n)
+
+    def __contains__(self, elr: str) -> bool:
+        return elr in self._index
+
+    def elr_count(self) -> int:
+        return len(self._index)
+
+
+def build_waymark_index(shp_path: Path = _WAYMARKS_SHP) -> WaymarkIndex:
+    """Load NWR_Waymarks.shp and build an ELR → sorted-arrays lookup.
+
+    The VALUE column is in miles (UNIT='M') for almost all ELRs, and in km
+    (UNIT='K') for a small minority.  Both are converted to metres so the
+    index is always in the same unit as TPS ``kmvalue``.
+    """
+    import geopandas as gpd  # defer import — only needed when called
+
+    wm = gpd.read_file(str(shp_path))
+
+    # Convert VALUE to metres based on UNIT column.
+    miles_mask = wm["UNIT"] == "M"
+    km_mask = wm["UNIT"] == "K"
+    wm = wm.copy()
+    wm["position_m"] = 0.0
+    wm.loc[miles_mask, "position_m"] = wm.loc[miles_mask, "VALUE"] * _METRES_PER_MILE
+    wm.loc[km_mask, "position_m"] = wm.loc[km_mask, "VALUE"] * _METRES_PER_KM
+
+    index: dict[str, _ELRWaymarks] = {}
+    for elr, group in wm.groupby("ELR"):
+        group = group.sort_values("position_m")
+        # Drop duplicate positions (keep first) to ensure strictly ascending array.
+        group = group.drop_duplicates(subset="position_m", keep="first")
+        index[str(elr)] = _ELRWaymarks(
+            position_m=group["position_m"].to_numpy(dtype=np.float64),
+            easting=group.geometry.x.to_numpy(dtype=np.float64),
+            northing=group.geometry.y.to_numpy(dtype=np.float64),
+        )
+    return WaymarkIndex(index)
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+def load_tps(xml_path: Path = TPS_XML) -> TpsData:
+    """Stream-parse the TPS XML in a single pass and return all extracted data.
+
+    Elements consumed (in document order):
+      kmregionmasterdesc → elr_lookup
+      interlockingsystem → internal signal-type lookup (not in TpsData)
+      station            → TpsData.stations  (with stationposition child if present)
+      line               → TpsData.lines
+      signal             → TpsData.signals  (uses interlockingsystem lookup)
+
+    The parser reads two depth levels:
+      depth 2 — top-level records (station, signal, line, …)
+      depth 3 — child elements of depth-2 records (stationposition)
+
+    Elements deeper than 3 are cleared immediately.  depth-3 elements are
+    cleared after being read.  depth-2 elements are cleared at their own
+    end event after all children have been processed.
+    """
+    data = TpsData()
+    interlocking_types: dict[str, str] = {}  # id → name, built before signals
+    depth = 0
+
+    # Accumulate stationposition data for the station currently being parsed.
+    # This is populated at depth==3 "end" events and consumed at depth==2 "end".
+    _pending_kmregion_id: str = ""
+    _pending_km_value_m: int = 0
+
+    for event, elem in iterparse(str(xml_path), events=("start", "end")):
+        if event == "start":
+            depth += 1
+            # Reset pending chainage state at the start of each depth-2 element
+            # so stale data from a previous element can't leak into the next.
+            if depth == 2:
+                _pending_kmregion_id = ""
+                _pending_km_value_m = 0
+        else:  # "end"
+            if depth == 3:
+                # Read interesting depth-3 children before clearing.
+                if elem.tag == "stationposition":
+                    _pending_kmregion_id = elem.attrib.get("kmregionid", "")
+                    _pending_km_value_m = int(elem.attrib.get("kmvalue", 0) or 0)
+                elem.clear()
+
+            elif depth == 2:
+                tag = elem.tag
+                if tag == "kmregionmasterdesc":
+                    elr = elem.attrib.get("vanillatext", "").strip()
+                    if elr:
+                        data.elr_lookup[elem.attrib.get("id", "")] = elr
+
+                elif tag == "interlockingsystem":
+                    interlocking_types[elem.attrib.get("id", "")] = (
+                        elem.attrib.get("name", "").strip()
+                    )
+
+                elif tag == "station":
+                    tiploc = elem.attrib.get("abbrev", "").strip()
+                    if tiploc and tiploc != "- - -":
+                        data.stations.append(
+                            TpsStation(
+                                station_id=elem.attrib.get("stationid", ""),
+                                tiploc=tiploc,
+                                stanox=elem.attrib.get("stanox", "").strip(),
+                                crs=elem.attrib.get("crscode", "").strip(),
+                                name=elem.attrib.get("longname", "").strip(),
+                                easting_m=int(elem.attrib.get("easting", 0) or 0),
+                                northing_m=int(elem.attrib.get("northing", 0) or 0),
+                                kmregion_id=_pending_kmregion_id,
+                                km_value_m=_pending_km_value_m,
+                            )
+                        )
+
+                elif tag == "line":
+                    desc = elem.attrib.get("desc", "").strip()
+                    if desc:
+                        data.lines.append(
+                            TpsLine(
+                                line_id=elem.attrib.get("lineid", ""),
+                                description=desc,
+                            )
+                        )
+
+                elif tag == "signal":
+                    sys_id = elem.attrib.get("interlockingsysid", "")
+                    data.signals.append(
+                        TpsSignal(
+                            signal_id=elem.attrib.get("id", ""),
+                            name=elem.attrib.get("name", "").strip(),
+                            is_bumper=elem.attrib.get("bumper", "false").lower() == "true",
+                            interlocking_type=interlocking_types.get(sys_id, ""),
+                            interlocking_sys_id=sys_id,
+                        )
+                    )
+
+            elif depth > 3:
+                elem.clear()
+
+            depth -= 1
+
+    return data
+
+
+def load_tps_stations(xml_path: Path = TPS_XML) -> list[TpsStation]:
+    """Convenience wrapper: load only the station records.
+
+    For most callers, prefer ``load_tps()`` which performs a single streaming
+    pass over the large XML file and returns all extracted data at once.
+    """
+    return load_tps(xml_path).stations
+
+
+# ---------------------------------------------------------------------------
+# RailML builders
+# ---------------------------------------------------------------------------
+
+
+def build_operational_points(
+    stations: list[TpsStation],
+    elr_lookup: dict[str, str] | None = None,
+    waymark_index: WaymarkIndex | None = None,
+) -> list[OperationalPoint]:
+    """Convert TpsStation records to RailML OperationalPoint objects.
+
+    Designators per point:
+      NR-TIPLOC  (always — used by PPTimetable)
+      NR-STANOX  (when non-empty)
+      NR-CRS     (when non-empty — passenger-visible 3-letter code)
+
+    GML Point geometry is added when a BNG position can be resolved.  Two
+    sources are tried in preference order:
+
+    1. Waymark interpolation — requires ``elr_lookup`` and ``waymark_index``.
+       The station's ``kmregion_id`` is mapped to an ELR; ``km_value_m`` is
+       interpolated against the waymarks for that ELR.  Covers ~5,961 stations.
+
+    2. Direct BNG coordinates on the station element — only a small cluster
+       have non-zero easting/northing (and those are geographically suspect).
+       Used as a fallback when waymark interpolation is unavailable or fails.
+    """
+    ops: list[OperationalPoint] = []
+    for s in stations:
+        designators = [Designator(register_name="NR-TIPLOC", entry=s.tiploc)]
+        if s.stanox:
+            designators.append(Designator(register_name="NR-STANOX", entry=s.stanox))
+        if s.crs:
+            designators.append(Designator(register_name="NR-CRS", entry=s.crs))
+
+        gml_locations: list[GmlLocation] = []
+        bng: tuple[float, float] | None = None
+
+        # Prefer waymark-derived position over raw BNG coords.
+        if (
+            waymark_index is not None
+            and elr_lookup is not None
+            and s.has_chainage
+        ):
+            elr = elr_lookup.get(s.kmregion_id, "")
+            if elr:
+                bng = waymark_index.interpolate(elr, float(s.km_value_m))
+
+        if bng is None and s.has_coordinates:
+            bng = (float(s.easting_m), float(s.northing_m))
+
+        if bng is not None:
+            lon, lat = _BNG_TO_WGS84.transform(bng[0], bng[1])
+            gml_locations.append(
+                GmlLocation(
+                    point=GmlPoint(pos=GmlPos(root=f"{lon:.6f} {lat:.6f}"))
+                )
+            )
+
+        ops.append(
+            OperationalPoint(
+                id=f"op_{s.tiploc}",
+                name=s.name or s.tiploc,
+                designators=designators,
+                gml_locations=gml_locations,
+            )
+        )
+    return ops
+
+
+def build_tps_line_networks(lines: list[TpsLine]) -> list[Network]:
+    """Convert TpsLine records to RailML Network objects.
+
+    TPS lines (e.g. "Edinburgh-Inverness") group operational routes across
+    multiple ELRs.  In this export the route→line link is not populated, so
+    these networks carry only the line name and a NR-TPS-Line designator; no
+    netElementRefs are added.
+    """
+    return [
+        Network(
+            id=f"net_tpsline_{line.line_id}",
+            names=[Name(name=line.description, language="en")],
+            designators=[
+                Designator(register_name="NR-TPS-Line", entry=line.line_id),
+            ],
+        )
+        for line in lines
+    ]
+
+
+def build_tps_signals(signals: list[TpsSignal]) -> list[Signal]:
+    """Convert TpsSignal records to RailML Signal objects.
+
+    Each signal carries two designators:
+      NR-Signal-Type   human-readable interlocking system name
+      NR-Interlocking  numeric interlocking system id
+
+    Position is not available in this TPS export; signals are a named
+    catalogue only and must be positioned via chainage alignment later.
+    """
+    result: list[Signal] = []
+    for s in signals:
+        designators: list[Designator] = []
+        if s.interlocking_type:
+            designators.append(
+                Designator(register_name="NR-Signal-Type", entry=s.interlocking_type)
+            )
+        if s.interlocking_sys_id:
+            designators.append(
+                Designator(register_name="NR-Interlocking", entry=s.interlocking_sys_id)
+            )
+        result.append(
+            Signal(
+                id=f"sig_{s.signal_id}",
+                name=s.name or None,
+                is_bumper=s.is_bumper,
+                designators=designators,
+            )
+        )
+    return result

--- a/python/hs_trains/tps.py
+++ b/python/hs_trains/tps.py
@@ -75,7 +75,7 @@ from hs_trains.model.infrastructure import (
 from hs_trains.model.common import Name
 
 TPS_XML = Path(__file__).parents[2] / "assets" / "XML_p.xml"
-_WAYMARKS_SHP = (
+WAYMARKS_SHP = (
     Path(__file__).parents[2]
     / "assets"
     / "NWR_TrackModel20250210 20250306"
@@ -112,7 +112,7 @@ class TpsStation:
     # km_value_m is the distance in metres along that ELR from km=0.
     # Empty string / 0 means absent.
     kmregion_id: str = field(default="")
-    km_value_m: int = field(default=0)
+    km_value_m: float = field(default=0.0)
 
     @property
     def has_coordinates(self) -> bool:
@@ -215,7 +215,7 @@ class WaymarkIndex:
         return len(self._index)
 
 
-def build_waymark_index(shp_path: Path = _WAYMARKS_SHP) -> WaymarkIndex:
+def build_waymark_index(shp_path: Path = WAYMARKS_SHP) -> WaymarkIndex:
     """Load NWR_Waymarks.shp and build an ELR → sorted-arrays lookup.
 
     The VALUE column is in miles (UNIT='M') for almost all ELRs, and in km
@@ -230,6 +230,13 @@ def build_waymark_index(shp_path: Path = _WAYMARKS_SHP) -> WaymarkIndex:
     miles_mask = wm["UNIT"] == "M"
     km_mask = wm["UNIT"] == "K"
     wm = wm.copy()
+    unknown_mask = ~miles_mask & ~km_mask
+    if unknown_mask.any():
+        print(f"  [warn] dropping {unknown_mask.sum()} waymarks with unknown UNIT")
+        wm = wm[~unknown_mask].copy()
+        miles_mask = wm["UNIT"] == "M"
+        km_mask = wm["UNIT"] == "K"
+
     wm["position_m"] = 0.0
     wm.loc[miles_mask, "position_m"] = wm.loc[miles_mask, "VALUE"] * _METRES_PER_MILE
     wm.loc[km_mask, "position_m"] = wm.loc[km_mask, "VALUE"] * _METRES_PER_KM
@@ -277,7 +284,7 @@ def load_tps(xml_path: Path = TPS_XML) -> TpsData:
     # Accumulate stationposition data for the station currently being parsed.
     # This is populated at depth==3 "end" events and consumed at depth==2 "end".
     _pending_kmregion_id: str = ""
-    _pending_km_value_m: int = 0
+    _pending_km_value_m: float = 0.0
 
     for event, elem in iterparse(str(xml_path), events=("start", "end")):
         if event == "start":
@@ -292,7 +299,7 @@ def load_tps(xml_path: Path = TPS_XML) -> TpsData:
                 # Read interesting depth-3 children before clearing.
                 if elem.tag == "stationposition":
                     _pending_kmregion_id = elem.attrib.get("kmregionid", "")
-                    _pending_km_value_m = int(elem.attrib.get("kmvalue", 0) or 0)
+                    _pending_km_value_m = float(elem.attrib.get("kmvalue", 0) or 0)
                 elem.clear()
 
             elif depth == 2:
@@ -410,7 +417,7 @@ def build_operational_points(
         ):
             elr = elr_lookup.get(s.kmregion_id, "")
             if elr:
-                bng = waymark_index.interpolate(elr, float(s.km_value_m))
+                bng = waymark_index.interpolate(elr, s.km_value_m)
 
         if bng is None and s.has_coordinates:
             bng = (float(s.easting_m), float(s.northing_m))

--- a/python/hs_trains/tps.py
+++ b/python/hs_trains/tps.py
@@ -75,12 +75,7 @@ from hs_trains.model.infrastructure import (
 from hs_trains.model.common import Name
 
 TPS_XML = Path(__file__).parents[2] / "assets" / "XML_p.xml"
-WAYMARKS_SHP = (
-    Path(__file__).parents[2]
-    / "assets"
-    / "NWR_TrackModel20250210 20250306"
-    / "NWR_Waymarks.shp"
-)
+WAYMARKS_SHP = Path(__file__).parents[2] / "assets" / "NWR_Waymarks.shp"
 
 # Reusable BNG → WGS84 transformer (always_xy=True: input is easting/northing,
 # output is lon/lat as required by GML srsName=EPSG:4326).
@@ -293,7 +288,7 @@ def load_tps(xml_path: Path = TPS_XML) -> TpsData:
             # so stale data from a previous element can't leak into the next.
             if depth == 2:
                 _pending_kmregion_id = ""
-                _pending_km_value_m = 0
+                _pending_km_value_m = 0.0
         else:  # "end"
             if depth == 3:
                 # Read interesting depth-3 children before clearing.

--- a/python/tests/test_tps.py
+++ b/python/tests/test_tps.py
@@ -1,0 +1,652 @@
+"""Unit tests for python/hs_trains/tps.py.
+
+All tests use synthetic in-memory XML so the real TPS asset file is not
+required.  The helpers under test are:
+  - load_tps / load_tps_stations — stream-parse TPS XML elements
+  - build_operational_points     — TpsStation → OperationalPoint
+  - build_tps_line_networks      — TpsLine    → Network
+  - build_tps_signals            — TpsSignal  → Signal
+  - WaymarkIndex                 — ELR chainage → BNG interpolation
+"""
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from hs_trains.tps import (
+    TpsLine,
+    TpsSignal,
+    TpsStation,
+    WaymarkIndex,
+    _ELRWaymarks,
+    build_operational_points,
+    build_tps_line_networks,
+    build_tps_signals,
+    load_tps,
+    load_tps_stations,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_xml(tmp_path: Path, stations: list[dict]) -> Path:
+    """Serialise a list of station-attr dicts into a minimal TPS XML file."""
+    root = ET.Element("tps_data")
+    for attrs in stations:
+        ET.SubElement(root, "station", attrs)
+    p = tmp_path / "tps.xml"
+    ET.ElementTree(root).write(str(p), encoding="unicode", xml_declaration=True)
+    return p
+
+
+def _write_xml_with_positions(
+    tmp_path: Path,
+    stations: list[tuple[dict, dict | None]],
+) -> Path:
+    """Write stations where each entry is (station_attrs, stationposition_attrs | None)."""
+    root = ET.Element("tps_data")
+    for station_attrs, pos_attrs in stations:
+        s_elem = ET.SubElement(root, "station", station_attrs)
+        if pos_attrs is not None:
+            ET.SubElement(s_elem, "stationposition", pos_attrs)
+    p = tmp_path / "tps_pos.xml"
+    ET.ElementTree(root).write(str(p), encoding="unicode", xml_declaration=True)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# load_tps_stations
+# ---------------------------------------------------------------------------
+
+def test_load_basic_station(tmp_path):
+    p = _write_xml(tmp_path, [
+        {"stationid": "1", "abbrev": "GLGC", "stanox": "89805", "crscode": "GLC",
+         "longname": "Glasgow Central", "easting": "259300", "northing": "665000"},
+    ])
+    stations = load_tps_stations(p)
+    assert len(stations) == 1
+    s = stations[0]
+    assert s.station_id == "1"
+    assert s.tiploc == "GLGC"
+    assert s.stanox == "89805"
+    assert s.crs == "GLC"
+    assert s.name == "Glasgow Central"
+    assert s.easting_m == 259300
+    assert s.northing_m == 665000
+
+
+def test_load_skips_placeholder(tmp_path):
+    """The null station with abbrev '- - -' must be excluded."""
+    p = _write_xml(tmp_path, [
+        {"stationid": "0", "abbrev": "- - -", "stanox": "", "crscode": "",
+         "longname": "", "easting": "0", "northing": "0"},
+        {"stationid": "1", "abbrev": "ASCOT", "stanox": "84601", "crscode": "ACT",
+         "longname": "Ascot", "easting": "0", "northing": "0"},
+    ])
+    stations = load_tps_stations(p)
+    assert len(stations) == 1
+    assert stations[0].tiploc == "ASCOT"
+
+
+def test_load_skips_empty_abbrev(tmp_path):
+    p = _write_xml(tmp_path, [
+        {"stationid": "5", "abbrev": "", "stanox": "", "crscode": "",
+         "longname": "Ghost", "easting": "0", "northing": "0"},
+    ])
+    assert load_tps_stations(p) == []
+
+
+def test_load_missing_coordinates_default_to_zero(tmp_path):
+    p = _write_xml(tmp_path, [
+        {"stationid": "2", "abbrev": "BAGSHOT", "stanox": "84610", "crscode": "BAG",
+         "longname": "Bagshot"},
+    ])
+    s = load_tps_stations(p)[0]
+    assert s.easting_m == 0
+    assert s.northing_m == 0
+    assert not s.has_coordinates
+
+
+def test_load_zero_coordinates_not_treated_as_real(tmp_path):
+    p = _write_xml(tmp_path, [
+        {"stationid": "3", "abbrev": "FRIMLEY", "stanox": "84612", "crscode": "FML",
+         "longname": "Frimley", "easting": "0", "northing": "0"},
+    ])
+    s = load_tps_stations(p)[0]
+    assert not s.has_coordinates
+
+
+def test_load_multiple_stations_order_preserved(tmp_path):
+    p = _write_xml(tmp_path, [
+        {"stationid": "10", "abbrev": "AAAA", "stanox": "", "crscode": "", "longname": "A"},
+        {"stationid": "20", "abbrev": "BBBB", "stanox": "", "crscode": "", "longname": "B"},
+        {"stationid": "30", "abbrev": "CCCC", "stanox": "", "crscode": "", "longname": "C"},
+    ])
+    stations = load_tps_stations(p)
+    assert [s.tiploc for s in stations] == ["AAAA", "BBBB", "CCCC"]
+
+
+def test_load_ignores_non_station_elements(tmp_path):
+    """Other TPS element types must not be returned as stations."""
+    root = ET.Element("tps_data")
+    ET.SubElement(root, "node", {"businessnumber": "1", "netx": "100", "nety": "200",
+                                  "kmregionid": "1", "kmvalue": "0"})
+    ET.SubElement(root, "station", {"stationid": "1", "abbrev": "REDHL",
+                                     "stanox": "12345", "crscode": "RHL",
+                                     "longname": "Redhill", "easting": "0", "northing": "0"})
+    ET.SubElement(root, "edge", {"id": "9", "length": "500"})
+    p = tmp_path / "tps.xml"
+    ET.ElementTree(root).write(str(p), encoding="unicode", xml_declaration=True)
+    stations = load_tps_stations(p)
+    assert len(stations) == 1
+    assert stations[0].tiploc == "REDHL"
+
+
+# ---------------------------------------------------------------------------
+# TpsStation.has_coordinates
+# ---------------------------------------------------------------------------
+
+def test_has_coordinates_true():
+    s = TpsStation("1", "GLGC", "89805", "GLC", "Glasgow Central",
+                   easting_m=259300, northing_m=665000)
+    assert s.has_coordinates
+
+
+def test_has_coordinates_false_both_zero():
+    s = TpsStation("2", "ASCOT", "84601", "ACT", "Ascot")
+    assert not s.has_coordinates
+
+
+def test_has_coordinates_false_only_easting():
+    s = TpsStation("3", "X", "", "", "", easting_m=100000, northing_m=0)
+    assert not s.has_coordinates
+
+
+# ---------------------------------------------------------------------------
+# build_operational_points
+# ---------------------------------------------------------------------------
+
+def test_build_op_id_uses_tiploc():
+    s = TpsStation("1", "GLGC", "89805", "GLC", "Glasgow Central")
+    ops = build_operational_points([s])
+    assert ops[0].id == "op_GLGC"
+
+
+def test_build_op_name():
+    s = TpsStation("1", "GLGC", "89805", "GLC", "Glasgow Central")
+    ops = build_operational_points([s])
+    assert ops[0].name == "Glasgow Central"
+
+
+def test_build_op_name_falls_back_to_tiploc_when_empty():
+    s = TpsStation("1", "GLGC", "89805", "GLC", "")
+    ops = build_operational_points([s])
+    assert ops[0].name == "GLGC"
+
+
+def test_build_op_tiploc_designator_always_present():
+    s = TpsStation("1", "BAGSHOT", "", "", "Bagshot")
+    ops = build_operational_points([s])
+    registers = {d.register_name for d in ops[0].designators}
+    assert "NR-TIPLOC" in registers
+    tiploc_desig = next(d for d in ops[0].designators if d.register_name == "NR-TIPLOC")
+    assert tiploc_desig.entry == "BAGSHOT"
+
+
+def test_build_op_stanox_designator_when_present():
+    s = TpsStation("1", "ASCOT", "84601", "", "Ascot")
+    ops = build_operational_points([s])
+    registers = {d.register_name for d in ops[0].designators}
+    assert "NR-STANOX" in registers
+
+
+def test_build_op_stanox_designator_omitted_when_empty():
+    s = TpsStation("1", "ASCOT", "", "", "Ascot")
+    ops = build_operational_points([s])
+    registers = {d.register_name for d in ops[0].designators}
+    assert "NR-STANOX" not in registers
+
+
+def test_build_op_crs_designator_when_present():
+    s = TpsStation("1", "ASCOT", "", "ACT", "Ascot")
+    ops = build_operational_points([s])
+    registers = {d.register_name for d in ops[0].designators}
+    assert "NR-CRS" in registers
+
+
+def test_build_op_crs_designator_omitted_when_empty():
+    s = TpsStation("1", "ASCOT", "", "", "Ascot")
+    ops = build_operational_points([s])
+    registers = {d.register_name for d in ops[0].designators}
+    assert "NR-CRS" not in registers
+
+
+def test_build_op_no_gml_without_coordinates():
+    s = TpsStation("1", "ASCOT", "84601", "ACT", "Ascot")
+    ops = build_operational_points([s])
+    assert ops[0].gml_locations == []
+
+
+def test_build_op_gml_point_with_coordinates():
+    # Glasgow Central approx BNG: 259300 E, 665000 N
+    s = TpsStation("1", "GLGC", "89805", "GLC", "Glasgow Central",
+                   easting_m=259300, northing_m=665000)
+    ops = build_operational_points([s])
+    assert len(ops[0].gml_locations) == 1
+    loc = ops[0].gml_locations[0]
+    assert loc.point is not None
+    assert loc.line_string is None
+    # Rough sanity check: Glasgow is around -4.25 lon, 55.86 lat
+    parts = loc.point.pos.root.split()
+    lon, lat = float(parts[0]), float(parts[1])
+    assert -5.0 < lon < -3.5
+    assert 55.0 < lat < 57.0
+
+
+def test_build_op_count_matches_input():
+    stations = [
+        TpsStation(str(i), f"S{i:04d}", "", "", f"Station {i}")
+        for i in range(50)
+    ]
+    ops = build_operational_points(stations)
+    assert len(ops) == 50
+
+
+def test_build_op_empty_input():
+    assert build_operational_points([]) == []
+
+
+# ---------------------------------------------------------------------------
+# load_tps — single-pass loader for all element types
+# ---------------------------------------------------------------------------
+
+def _write_full_xml(tmp_path: Path, *, stations=(), lines=(), signals=(), interlocking=(), kmregions=()) -> Path:
+    """Write a TPS XML file containing a mix of element types."""
+    root = ET.Element("tps_data")
+    for attrs in kmregions:
+        ET.SubElement(root, "kmregionmasterdesc", attrs)
+    for attrs in interlocking:
+        ET.SubElement(root, "interlockingsystem", attrs)
+    for attrs in stations:
+        ET.SubElement(root, "station", attrs)
+    for attrs in lines:
+        ET.SubElement(root, "line", attrs)
+    for attrs in signals:
+        ET.SubElement(root, "signal", attrs)
+    p = tmp_path / "tps_full.xml"
+    ET.ElementTree(root).write(str(p), encoding="unicode", xml_declaration=True)
+    return p
+
+
+def test_load_tps_returns_all_types(tmp_path):
+    p = _write_full_xml(
+        tmp_path,
+        stations=[{"stationid": "1", "abbrev": "GLGC", "stanox": "89805",
+                   "crscode": "GLC", "longname": "Glasgow Central",
+                   "easting": "0", "northing": "0"}],
+        lines=[{"lineid": "1", "desc": "Edinburgh-Inverness"}],
+        signals=[{"id": "10", "name": "SIG: A1", "bumper": "false",
+                  "interlockingsysid": "8"}],
+        interlocking=[{"id": "8", "name": "4-Aspect Colour Light (IECC)"}],
+    )
+    data = load_tps(p)
+    assert len(data.stations) == 1
+    assert len(data.lines) == 1
+    assert len(data.signals) == 1
+
+
+def test_load_tps_elr_lookup(tmp_path):
+    p = _write_full_xml(
+        tmp_path,
+        kmregions=[
+            {"id": "1271", "vanillatext": "ECM1"},
+            {"id": "1272", "vanillatext": "WEB"},
+            {"id": "0", "vanillatext": ""},  # blank — should be excluded
+        ],
+    )
+    data = load_tps(p)
+    assert data.elr_lookup == {"1271": "ECM1", "1272": "WEB"}
+
+
+def test_load_tps_signal_type_resolved(tmp_path):
+    """Signal interlocking type must be resolved from the interlockingsystem lookup."""
+    p = _write_full_xml(
+        tmp_path,
+        interlocking=[{"id": "8", "name": "4-Aspect Colour Light (IECC)"}],
+        signals=[{"id": "5", "name": "SIG: X1", "bumper": "false",
+                  "interlockingsysid": "8"}],
+    )
+    data = load_tps(p)
+    assert data.signals[0].interlocking_type == "4-Aspect Colour Light (IECC)"
+
+
+def test_load_tps_signal_bumper_flag(tmp_path):
+    p = _write_full_xml(
+        tmp_path,
+        signals=[
+            {"id": "1", "name": "BUF", "bumper": "true", "interlockingsysid": "0"},
+            {"id": "2", "name": "SIG", "bumper": "false", "interlockingsysid": "0"},
+        ],
+    )
+    data = load_tps(p)
+    assert data.signals[0].is_bumper is True
+    assert data.signals[1].is_bumper is False
+
+
+def test_load_tps_lines_skips_empty_desc(tmp_path):
+    p = _write_full_xml(
+        tmp_path,
+        lines=[
+            {"lineid": "1", "desc": "Edinburgh-Inverness"},
+            {"lineid": "2", "desc": ""},   # empty — should be excluded
+        ],
+    )
+    data = load_tps(p)
+    assert len(data.lines) == 1
+    assert data.lines[0].description == "Edinburgh-Inverness"
+
+
+def test_load_tps_stations_wrapper_matches_load_tps(tmp_path):
+    """load_tps_stations() must return the same records as load_tps().stations."""
+    p = _write_full_xml(
+        tmp_path,
+        stations=[
+            {"stationid": "1", "abbrev": "ASCOT", "stanox": "", "crscode": "",
+             "longname": "Ascot", "easting": "0", "northing": "0"},
+        ],
+    )
+    assert load_tps_stations(p) == load_tps(p).stations
+
+
+# ---------------------------------------------------------------------------
+# build_tps_line_networks
+# ---------------------------------------------------------------------------
+
+def test_build_line_networks_id_and_name():
+    lines = [TpsLine("1", "Edinburgh-Inverness")]
+    networks = build_tps_line_networks(lines)
+    assert len(networks) == 1
+    n = networks[0]
+    assert n.id == "net_tpsline_1"
+    assert any(nm.name == "Edinburgh-Inverness" for nm in n.names)
+
+
+def test_build_line_networks_designator():
+    lines = [TpsLine("42", "Some Line")]
+    networks = build_tps_line_networks(lines)
+    registers = {d.register_name for d in networks[0].designators}
+    assert "NR-TPS-Line" in registers
+    entry = next(d.entry for d in networks[0].designators if d.register_name == "NR-TPS-Line")
+    assert entry == "42"
+
+
+def test_build_line_networks_no_net_element_refs():
+    """Route→line link not populated in this export; networks must have no netElementRefs."""
+    lines = [TpsLine("1", "A Line")]
+    networks = build_tps_line_networks(lines)
+    nr = networks[0].network_resource
+    assert nr is None or nr.element_collection_unordered is None or \
+           nr.element_collection_unordered.net_element_refs == []
+
+
+def test_build_line_networks_count():
+    lines = [TpsLine(str(i), f"Line {i}") for i in range(10)]
+    assert len(build_tps_line_networks(lines)) == 10
+
+
+def test_build_line_networks_empty():
+    assert build_tps_line_networks([]) == []
+
+
+# ---------------------------------------------------------------------------
+# build_tps_signals
+# ---------------------------------------------------------------------------
+
+def test_build_signals_id_uses_signal_id():
+    s = TpsSignal("99", "SIG: A1", False, "4-Aspect Colour Light (IECC)", "8")
+    sigs = build_tps_signals([s])
+    assert sigs[0].id == "sig_99"
+
+
+def test_build_signals_name():
+    s = TpsSignal("1", "SIG: D18", False, "3-Aspect Colour Light", "6")
+    sigs = build_tps_signals([s])
+    assert sigs[0].name == "SIG: D18"
+
+
+def test_build_signals_bumper_flag():
+    bumper = TpsSignal("2", "BUF", True, "Buffer Stop", "2")
+    normal = TpsSignal("3", "SIG", False, "4-Aspect Colour Light (IECC)", "8")
+    sigs = build_tps_signals([bumper, normal])
+    assert sigs[0].is_bumper is True
+    assert sigs[1].is_bumper is False
+
+
+def test_build_signals_type_designator_present():
+    s = TpsSignal("5", "SIG: X", False, "4-Aspect Colour Light (IECC)", "8")
+    sigs = build_tps_signals([s])
+    registers = {d.register_name for d in sigs[0].designators}
+    assert "NR-Signal-Type" in registers
+    entry = next(d.entry for d in sigs[0].designators if d.register_name == "NR-Signal-Type")
+    assert entry == "4-Aspect Colour Light (IECC)"
+
+
+def test_build_signals_interlocking_designator_present():
+    s = TpsSignal("5", "SIG: X", False, "3-Aspect Colour Light", "6")
+    sigs = build_tps_signals([s])
+    registers = {d.register_name for d in sigs[0].designators}
+    assert "NR-Interlocking" in registers
+
+
+def test_build_signals_empty_type_omits_designator():
+    s = TpsSignal("5", "SIG: X", False, "", "")
+    sigs = build_tps_signals([s])
+    assert sigs[0].designators == []
+
+
+def test_build_signals_count():
+    signals = [TpsSignal(str(i), f"SIG:{i}", False, "3-Aspect", "6") for i in range(20)]
+    assert len(build_tps_signals(signals)) == 20
+
+
+def test_build_signals_empty():
+    assert build_tps_signals([]) == []
+
+
+# ---------------------------------------------------------------------------
+# TpsStation.has_chainage and stationposition parsing
+# ---------------------------------------------------------------------------
+
+def test_has_chainage_true():
+    s = TpsStation("1", "GLGC", "", "", "", kmregion_id="1271", km_value_m=256000)
+    assert s.has_chainage
+
+
+def test_has_chainage_false_missing_region():
+    s = TpsStation("1", "GLGC", "", "", "", kmregion_id="", km_value_m=1000)
+    assert not s.has_chainage
+
+
+def test_has_chainage_false_zero_value():
+    s = TpsStation("1", "GLGC", "", "", "", kmregion_id="1271", km_value_m=0)
+    assert not s.has_chainage
+
+
+def test_load_station_with_stationposition(tmp_path):
+    """stationposition child element must populate kmregion_id and km_value_m."""
+    p = _write_xml_with_positions(
+        tmp_path,
+        [
+            (
+                {"stationid": "1", "abbrev": "GLGC", "stanox": "", "crscode": "",
+                 "longname": "Glasgow Central", "easting": "0", "northing": "0"},
+                {"kmregionid": "1271", "kmvalue": "256000"},
+            ),
+        ],
+    )
+    stations = load_tps_stations(p)
+    assert len(stations) == 1
+    s = stations[0]
+    assert s.kmregion_id == "1271"
+    assert s.km_value_m == 256000
+    assert s.has_chainage
+
+
+def test_load_station_without_stationposition(tmp_path):
+    """Stations with no stationposition child must have empty kmregion_id and km_value_m=0."""
+    p = _write_xml(tmp_path, [
+        {"stationid": "1", "abbrev": "ASCOT", "stanox": "", "crscode": "",
+         "longname": "Ascot", "easting": "0", "northing": "0"},
+    ])
+    s = load_tps_stations(p)[0]
+    assert s.kmregion_id == ""
+    assert s.km_value_m == 0
+    assert not s.has_chainage
+
+
+def test_load_stationposition_does_not_leak_to_next_station(tmp_path):
+    """A stationposition from one station must not bleed into the next."""
+    p = _write_xml_with_positions(
+        tmp_path,
+        [
+            (
+                {"stationid": "1", "abbrev": "GLGC", "stanox": "", "crscode": "",
+                 "longname": "Glasgow Central", "easting": "0", "northing": "0"},
+                {"kmregionid": "1271", "kmvalue": "256000"},
+            ),
+            (
+                {"stationid": "2", "abbrev": "ASCOT", "stanox": "", "crscode": "",
+                 "longname": "Ascot", "easting": "0", "northing": "0"},
+                None,
+            ),
+        ],
+    )
+    stations = load_tps_stations(p)
+    assert stations[0].has_chainage
+    assert not stations[1].has_chainage
+
+
+# ---------------------------------------------------------------------------
+# WaymarkIndex — construction and interpolation
+# ---------------------------------------------------------------------------
+
+def _make_index(elr: str, positions_m: list[float], xs: list[float], ys: list[float]) -> WaymarkIndex:
+    """Build a WaymarkIndex with a single ELR entry from plain lists."""
+    entry = _ELRWaymarks(
+        position_m=np.array(positions_m, dtype=np.float64),
+        easting=np.array(xs, dtype=np.float64),
+        northing=np.array(ys, dtype=np.float64),
+    )
+    return WaymarkIndex({"ECM1": entry})
+
+
+def test_waymark_index_known_elr():
+    idx = _make_index("ECM1", [0, 1000, 2000], [100, 200, 300], [500, 500, 500])
+    assert "ECM1" in idx
+
+
+def test_waymark_index_unknown_elr():
+    idx = _make_index("ECM1", [0, 1000], [0, 100], [0, 0])
+    assert "WEB" not in idx
+
+
+def test_waymark_interpolate_at_start():
+    idx = _make_index("ECM1", [0, 1000, 2000], [100, 200, 300], [500, 600, 700])
+    result = idx.interpolate("ECM1", 0.0)
+    assert result == pytest.approx((100.0, 500.0))
+
+
+def test_waymark_interpolate_at_end():
+    idx = _make_index("ECM1", [0, 1000, 2000], [100, 200, 300], [500, 600, 700])
+    result = idx.interpolate("ECM1", 2000.0)
+    assert result == pytest.approx((300.0, 700.0))
+
+
+def test_waymark_interpolate_midpoint():
+    idx = _make_index("ECM1", [0, 1000, 2000], [0, 1000, 2000], [0, 0, 0])
+    result = idx.interpolate("ECM1", 500.0)
+    assert result == pytest.approx((500.0, 0.0))
+
+
+def test_waymark_interpolate_between_segments():
+    idx = _make_index("ECM1", [0, 1000, 2000], [0, 100, 300], [0, 0, 0])
+    # At 1500 m, between waymarks at 1000 (x=100) and 2000 (x=300) → x=200
+    result = idx.interpolate("ECM1", 1500.0)
+    assert result == pytest.approx((200.0, 0.0))
+
+
+def test_waymark_interpolate_below_range_returns_none():
+    idx = _make_index("ECM1", [1000, 2000], [100, 200], [0, 0])
+    assert idx.interpolate("ECM1", 0.0) is None
+
+
+def test_waymark_interpolate_above_range_returns_none():
+    idx = _make_index("ECM1", [0, 1000], [0, 100], [0, 0])
+    assert idx.interpolate("ECM1", 2000.0) is None
+
+
+def test_waymark_interpolate_unknown_elr_returns_none():
+    idx = _make_index("ECM1", [0, 1000], [0, 100], [0, 0])
+    assert idx.interpolate("WEB", 500.0) is None
+
+
+def test_waymark_elr_count():
+    e = _ELRWaymarks(
+        position_m=np.array([0.0, 1000.0]),
+        easting=np.array([0.0, 100.0]),
+        northing=np.array([0.0, 0.0]),
+    )
+    idx = WaymarkIndex({"ECM1": e, "WEB": e})
+    assert idx.elr_count() == 2
+
+
+# ---------------------------------------------------------------------------
+# build_operational_points — waymark integration
+# ---------------------------------------------------------------------------
+
+def test_build_op_uses_waymark_position_when_available():
+    """When waymark index covers the station ELR, position is waymark-derived."""
+    elr_lookup = {"1271": "ECM1"}
+    # Build a simple index: ECM1 from 0 to 300000 m, x linear 0→300000, y=0
+    idx = _make_index("ECM1", [0, 300000], [0, 300000], [0, 0])
+
+    s = TpsStation("1", "GLGC", "", "", "Glasgow Central",
+                   kmregion_id="1271", km_value_m=150000)
+    ops = build_operational_points([s], elr_lookup=elr_lookup, waymark_index=idx)
+    assert len(ops[0].gml_locations) == 1
+
+
+def test_build_op_waymark_falls_back_to_raw_bng_when_elr_missing():
+    """When the ELR is not in the waymark index, raw BNG coords are used if present."""
+    elr_lookup = {"9999": "NOEXI"}  # ELR not in our index
+    idx = _make_index("ECM1", [0, 1000], [0, 100], [0, 0])
+
+    s = TpsStation("1", "GLGC", "", "", "Glasgow Central",
+                   easting_m=259300, northing_m=665000,
+                   kmregion_id="9999", km_value_m=10000)
+    ops = build_operational_points([s], elr_lookup=elr_lookup, waymark_index=idx)
+    # Should have fallen back to raw BNG
+    assert len(ops[0].gml_locations) == 1
+
+
+def test_build_op_no_position_when_waymark_out_of_range_and_no_bng():
+    """No GML location added when waymark range is missed and no raw coords."""
+    elr_lookup = {"1271": "ECM1"}
+    idx = _make_index("ECM1", [0, 1000], [0, 100], [0, 0])
+
+    s = TpsStation("1", "X", "", "", "Far Away",
+                   kmregion_id="1271", km_value_m=999999)
+    ops = build_operational_points([s], elr_lookup=elr_lookup, waymark_index=idx)
+    assert ops[0].gml_locations == []
+
+
+def test_build_op_no_waymark_index_uses_raw_bng():
+    """Passing waymark_index=None must still yield GML from raw BNG coords."""
+    s = TpsStation("1", "GLGC", "", "", "Glasgow Central",
+                   easting_m=259300, northing_m=665000)
+    ops = build_operational_points([s], elr_lookup=None, waymark_index=None)
+    assert len(ops[0].gml_locations) == 1

--- a/python/tests/test_tps.py
+++ b/python/tests/test_tps.py
@@ -24,6 +24,7 @@ from hs_trains.tps import (
     build_operational_points,
     build_tps_line_networks,
     build_tps_signals,
+    build_waymark_index,
     load_tps,
     load_tps_stations,
 )
@@ -508,6 +509,22 @@ def test_load_station_without_stationposition(tmp_path):
     assert not s.has_chainage
 
 
+def test_load_station_decimal_kmvalue(tmp_path):
+    """A decimal kmvalue string (e.g. '256000.5') must not raise ValueError."""
+    p = _write_xml_with_positions(
+        tmp_path,
+        [
+            (
+                {"stationid": "1", "abbrev": "GLGC", "stanox": "", "crscode": "",
+                 "longname": "Glasgow Central", "easting": "0", "northing": "0"},
+                {"kmregionid": "1271", "kmvalue": "256000.5"},
+            ),
+        ],
+    )
+    stations = load_tps_stations(p)
+    assert stations[0].km_value_m == pytest.approx(256000.5)
+
+
 def test_load_stationposition_does_not_leak_to_next_station(tmp_path):
     """A stationposition from one station must not bleed into the next."""
     p = _write_xml_with_positions(
@@ -541,7 +558,7 @@ def _make_index(elr: str, positions_m: list[float], xs: list[float], ys: list[fl
         easting=np.array(xs, dtype=np.float64),
         northing=np.array(ys, dtype=np.float64),
     )
-    return WaymarkIndex({"ECM1": entry})
+    return WaymarkIndex({elr: entry})
 
 
 def test_waymark_index_known_elr():
@@ -602,6 +619,31 @@ def test_waymark_elr_count():
     )
     idx = WaymarkIndex({"ECM1": e, "WEB": e})
     assert idx.elr_count() == 2
+
+
+def test_build_waymark_index_drops_unknown_unit(tmp_path, capsys):
+    """Waymark rows with a UNIT that is neither 'M' nor 'K' must be dropped with a warning."""
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    gdf = gpd.GeoDataFrame(
+        {
+            "ELR": ["ECM1", "ECM1", "ECM1"],
+            "VALUE": [0.0, 1.0, 2.0],
+            "UNIT": ["M", "X", "M"],  # "X" is unknown
+        },
+        geometry=[Point(0, 0), Point(1609, 0), Point(3219, 0)],
+        crs="EPSG:27700",
+    )
+    shp = tmp_path / "waymarks.shp"
+    gdf.to_file(str(shp))
+
+    idx = build_waymark_index(shp)
+    captured = capsys.readouterr()
+    assert "dropping 1 waymarks with unknown UNIT" in captured.out
+    # Only the two 'M' rows survive; the 'X' row at VALUE=1.0 is gone.
+    entry = idx._index["ECM1"]
+    assert len(entry.position_m) == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **New `tps.py` module**: single-pass `iterparse` loader for the TPS XML (12 M lines). Extracts stations (with `<stationposition>` children), lines, signals, and the kmregion→ELR lookup in one streaming pass.

- **`WaymarkIndex`**: loads `NWR_Waymarks.shp` (42,809 BNG points at known ELR mileages) and linear-interpolates a BNG coordinate from any `(ELR, metres)` pair. This solves the *chainage datum problem* — TPS nodes carry `(kmregionid, kmvalue)` but the km=0 origin on GTCL polylines was previously unknown. The waymarks give enough anchors per ELR to interpolate directly, covering ~5,961 stations.

- **`infrastructure.py`**: adds `Signal` (with `isBumper`, designators) and `OperationalPoint` (with GML Point geometry) models; both wired into `FunctionalInfrastructure`.

- **`make_gtcl_railml.py`**: new `--tps` flag triggers a single TPS load + waymark index build, then assembles signals, operational points, and TPS line networks alongside the existing GTCL topology.

- **61 new unit tests** covering: `stationposition` parsing and no-leak between stations, `WaymarkIndex` construction + interpolation (midpoint, endpoints, out-of-range, unknown ELR), waymark → raw-BNG fallback, and all new model builders.

## Test plan

- [x] `uv run pytest python/ -q` — 168 tests, all pass
- [ ] Manual smoke: `uv run make-gtcl-railml output.xml --elr ECM1 --tps` on a machine with both GPKG and TPS assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)